### PR TITLE
fix: extract query JSON from reasoning model output

### DIFF
--- a/apps/web/src/lib/scraper/extract-prices.test.ts
+++ b/apps/web/src/lib/scraper/extract-prices.test.ts
@@ -655,6 +655,14 @@ describe('extractJsonArray (issue #139 — wrappers around the array)', () => {
     const r = extractJsonArray('[{"airline":"Spirit [LCC]","price":98}]');
     expect(r.ok && r.value).toEqual([{ airline: 'Spirit [LCC]', price: 98 }]);
   });
+  it('preserves escaped quotes, backslashes and nested arrays in flight rows', () => {
+    const flights = [{ airline: 'Spirit "] {LCC}" \\', price: 98, layovers: [{ airport: 'ORD' }] }];
+    const r = extractJsonArray(`Results:\n${JSON.stringify(flights)}\nNotes: [not JSON]`);
+    expect(r).toEqual({ ok: true, value: flights });
+  });
+  it('finds flight rows after an unclosed prose bracket', () => {
+    expect(extractJsonArray('Notes [unfinished\n[{"price":98}]')).toEqual({ ok: true, value: [{ price: 98 }] });
+  });
   it('reports no_json_in_response when there is no array at all', () => {
     const r = extractJsonArray('I could not find any flights.');
     expect(r).toEqual({ ok: false, reason: 'no_json_in_response' });

--- a/apps/web/src/lib/scraper/extract-prices.ts
+++ b/apps/web/src/lib/scraper/extract-prices.ts
@@ -190,10 +190,10 @@ export interface ExtractionResult {
 }
 
 /**
- * Find the index of the ']' that closes the '[' at `start`, ignoring brackets
+ * Find the index of the closing delimiter for the opening one at `start`, ignoring delimiters
  * that appear inside JSON string literals. Returns -1 when unbalanced.
  */
-function matchingArrayEnd(text: string, start: number): number {
+export function matchingJsonEnd(text: string, start: number, open: string, close: string): number {
   let depth = 0;
   let inStr = false;
   let escaped = false;
@@ -206,8 +206,8 @@ function matchingArrayEnd(text: string, start: number): number {
       continue;
     }
     if (ch === '"') inStr = true;
-    else if (ch === '[') depth++;
-    else if (ch === ']' && --depth === 0) return i;
+    else if (ch === open) depth++;
+    else if (ch === close && --depth === 0) return i;
   }
   return -1;
 }
@@ -235,7 +235,7 @@ export function extractJsonArray(
   let firstArray: unknown[] | null = null;
   for (let start = text.indexOf('['); start !== -1; start = text.indexOf('[', start + 1)) {
     sawBracket = true;
-    const end = matchingArrayEnd(text, start);
+    const end = matchingJsonEnd(text, start, '[', ']');
     if (end === -1) continue;
     let parsed: unknown;
     try {

--- a/apps/web/src/lib/scraper/parse-query.test.ts
+++ b/apps/web/src/lib/scraper/parse-query.test.ts
@@ -45,13 +45,85 @@ vi.mock('./ai-registry', async (importOriginal) => {
 // Provide a fake API key so the provider check passes
 process.env.ANTHROPIC_API_KEY = 'test-key';
 
-import { parseFlightQuery } from './parse-query';
+import { extractJsonObject, parseFlightQuery } from './parse-query';
 
 function makeLlmResponse(data: Record<string, unknown>): string {
   return JSON.stringify(data);
 }
 
 describe('parseFlightQuery', () => {
+  const query = {
+    origins: [{ code: 'JFK', name: 'New York {JFK} "Terminal" \\' }],
+    destinations: [{ code: 'BKK', name: 'Bangkok [BKK]' }],
+    dateFrom: '2026-12-20', dateTo: '2026-12-26', cabinClass: 'economy',
+  };
+  const envelope = {
+    confidence: 'medium', parsed: query,
+    ambiguities: [{ field: 'origin', question: 'Which New York airport?', options: ['JFK', 'EWR'] }],
+  };
+  const answer = JSON.stringify(envelope);
+  it.each([
+    { name: 'reasoning with a conflicting query', content: `<ThInK>${JSON.stringify({ ...envelope, parsed: { origin: 'LAX', destination: 'SFO' } })}</ThInK>\n${answer}` },
+    { name: 'a trailing explanation and another object', content: `${answer}\nI used economy as requested. {"note":"1 seat"}` },
+    { name: 'a markdown fence', content: `\`\`\`json\n${answer}\n\`\`\`` },
+    { name: 'nested wrapper metadata', content: JSON.stringify({ confidence: 'high', result: envelope }) },
+    { name: 'an unclosed reasoning block with a draft', content: `<think>Draft: {"origin":"NYC"}\nFinal answer:\n${answer}` },
+    { name: 'differently tagged reasoning', content: `<analysis>{"confidence":"low","note":"draft"}</analysis>\n${answer}` },
+    { name: 'a malformed prefix and stray closing brace', content: `I need { valid JSON. {"broken": }\n${answer}\nDone }` },
+    { name: 'several unrelated objects', content: `{} {"note":"NYC means New York"}\n${answer}` },
+  ])('preserves the query and clarification in $name (issue #201)', async ({ content }) => {
+    mockExtract.mockResolvedValueOnce({ content, usage: { inputTokens: 100, outputTokens: 50 } });
+    const { response, usage } = await parseFlightQuery('NYC to Bangkok December 20-26th, Eco, 1 seat');
+    expect(response).toMatchObject({
+      confidence: 'medium', ambiguities: envelope.ambiguities, dateSpanDays: 6,
+      parsed: { ...query, origin: 'JFK', destination: 'BKK' },
+    });
+    expect(usage).toEqual({ inputTokens: 100, outputTokens: 50 });
+  });
+  it.each([
+    { origin: 'JFK', destination: 'BKK' },
+    { origins: query.origins, destinations: query.destinations },
+  ])('finds legacy routes inside a wrapper: %j', async (route) => {
+    const content = JSON.stringify({ note: { origin: 'draft' }, result: { ...route, dateFrom: query.dateFrom, dateTo: query.dateTo } });
+    mockExtract.mockResolvedValueOnce({ content, usage: { inputTokens: 100, outputTokens: 50 } });
+    const { response } = await parseFlightQuery('NYC to Bangkok December 20-26');
+    expect(response).toMatchObject({ confidence: 'high', parsed: { origin: 'JFK', destination: 'BKK', dateFrom: query.dateFrom, dateTo: query.dateTo } });
+  });
+  it('preserves a wrapped null answer and its clarification', async () => {
+    const value = { confidence: 'low', parsed: null, ambiguities: [{ field: 'general', question: 'Where do you want to fly?' }] };
+    mockExtract.mockResolvedValueOnce({ content: JSON.stringify({ result: value }), usage: { inputTokens: 10, outputTokens: 10 } });
+    expect((await parseFlightQuery('hello')).response).toEqual({ ...value, dateSpanDays: 0 });
+  });
+  it('prefers incomplete routes and leaves required-field validation to the parser', async () => {
+    const value = { origin: 'JFK', destination: 'BKK' };
+    const content = `{"note":"dates missing"}\n${JSON.stringify(value)}`;
+    expect(extractJsonObject(content)).toEqual({ ok: true, value });
+    mockExtract.mockResolvedValueOnce({ content, usage: { inputTokens: 10, outputTokens: 10 } });
+    expect((await parseFlightQuery('JFK to BKK')).response).toMatchObject({ parsed: null, confidence: 'low', ambiguities: [{ field: 'general' }] });
+  });
+  it('retains the first generic object when no query-shaped candidate exists', () => {
+    expect(extractJsonObject('{"note":"first"} {"note":"second"}')).toEqual({ ok: true, value: { note: 'first' } });
+  });
+  it('turns an empty answer into a clarification', async () => {
+    mockExtract.mockResolvedValueOnce({ content: '{}', usage: { inputTokens: 10, outputTokens: 10 } });
+    expect((await parseFlightQuery('hello')).response).toMatchObject({ parsed: null, confidence: 'low', ambiguities: [{ field: 'general' }] });
+  });
+  it.each([
+    ['<think>{"draft":true}</think>Sorry, I cannot parse that.', 'no_json_in_response'],
+    ['{"origin":', 'json_parse_error'],
+    ['{broken} {"invalid": }', 'json_parse_error'],
+  ])('reports failed extraction for %s', async (content, reason) => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      mockExtract.mockResolvedValueOnce({ content, usage: { inputTokens: 10, outputTokens: 10 } });
+      await expect(parseFlightQuery('hello')).rejects.toThrow('parse LLM response');
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining(`FAIL ${reason}`));
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('provider=anthropic'));
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   beforeEach(() => {
     mockExtract.mockReset();
   });
@@ -454,7 +526,7 @@ describe('parseFlightQuery', () => {
 
   it('logs a preview when JSON parse fails on a malformed block (issue #84)', async () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    // Regex finds { ... } but the contents are not valid JSON (unquoted keys).
+    // The braces balance but the contents are not valid JSON (unquoted keys).
     mockExtract.mockResolvedValue({
       content: 'Here is the result: { foo: bar } and more',
       usage: { inputTokens: 50, outputTokens: 20 },

--- a/apps/web/src/lib/scraper/parse-query.ts
+++ b/apps/web/src/lib/scraper/parse-query.ts
@@ -1,6 +1,7 @@
 import { EXTRACTION_PROVIDERS, CLI_PROVIDERS, LOCAL_PROVIDERS, resolveApiKey, type ExtractionResult } from './ai-registry';
 import { prisma } from '@/lib/prisma';
 import { normalizeCabinClass } from '@/lib/cabin-class';
+import { matchingJsonEnd } from './extract-prices';
 
 export interface Airport {
   code: string; // IATA 3-letter code
@@ -223,6 +224,37 @@ function normalizeAirports(parsed: Record<string, unknown>): ParsedFlightQuery {
   };
 }
 
+/** Extract a query object from reasoning, prose, fences, or a JSON wrapper. */
+export function extractJsonObject(
+  content: string,
+): { ok: true; value: Record<string, unknown> } | { ok: false; reason: 'no_json_in_response' | 'json_parse_error' } {
+  const text = content.replace(/<think>[\s\S]*?<\/think>/gi, '');
+  let sawBrace = false;
+  let firstObject: Record<string, unknown> | null = null;
+  for (let start = text.indexOf('{'); start !== -1; start = text.indexOf('{', start + 1)) {
+    sawBrace = true;
+    const end = matchingJsonEnd(text, start, '{', '}');
+    if (end === -1) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text.slice(start, end + 1));
+    } catch {
+      continue;
+    }
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) continue;
+    const object = parsed as Record<string, unknown>;
+    // A draft or wrapper may parse before the answer. Prefer the envelope
+    // (including parsed:null) or a flat route; validation stays downstream.
+    const isEnvelope = 'confidence' in object && 'parsed' in object;
+    const isFlatQuery = ('origin' in object || 'origins' in object)
+      && ('destination' in object || 'destinations' in object);
+    if (isEnvelope || isFlatQuery) return { ok: true, value: object };
+    if (firstObject === null) firstObject = object;
+  }
+  if (firstObject !== null) return { ok: true, value: firstObject };
+  return { ok: false, reason: sawBrace ? 'json_parse_error' : 'no_json_in_response' };
+}
+
 export async function parseFlightQuery(
   rawInput: string,
   conversationHistory?: Array<{ role: 'user' | 'assistant'; content: string }>
@@ -282,7 +314,7 @@ export async function parseFlightQuery(
         ? { timeoutMs: config.extractTimeoutSeconds * 1000 }
         : {}),
       // Constrain local providers to emit a JSON object. Without this, small
-      // Ollama models occasionally return prose or a refusal and the regex
+      // Ollama models occasionally return prose or a refusal and extraction
       // below finds nothing (issue #84). Gated to LOCAL_PROVIDERS only because
       // custom OpenAI compatible endpoints (OPENAI_BASE_URL, OpenRouter, etc.)
       // may route to models that reject `response_format` outright; the
@@ -291,26 +323,16 @@ export async function parseFlightQuery(
     }
   );
 
-  const jsonMatch = result.content.match(/\{[\s\S]*\}/);
-  if (!jsonMatch) {
+  const extracted = extractJsonObject(result.content);
+  if (!extracted.ok) {
     const preview = result.content.slice(0, 200).replace(/\s+/g, ' ');
     console.error(
-      `[parse-query] FAIL no_json_in_response provider=${provider} model=${model} length=${result.content.length} preview=${preview}`,
+      `[parse-query] FAIL ${extracted.reason} provider=${provider} model=${model} length=${result.content.length} preview=${preview}`,
     );
     throw new Error('Failed to parse LLM response as JSON');
   }
 
-  let raw: Record<string, unknown>;
-  try {
-    raw = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    const preview = jsonMatch[0].slice(0, 200).replace(/\s+/g, ' ');
-    console.error(
-      `[parse-query] FAIL json_parse_error provider=${provider} model=${model} length=${jsonMatch[0].length} err=${msg} preview=${preview}`,
-    );
-    throw new Error('Failed to parse LLM response as JSON', { cause: err });
-  }
+  const raw = extracted.value;
 
   // Handle both old format (flat ParsedFlightQuery) and new format (with confidence envelope)
   let parsed: ParsedFlightQuery | null;


### PR DESCRIPTION
## Summary

Natural-language search can fail when a reasoning model includes JSON in a `<think>` block or appends another object after its answer. The greedy regex joins these objects and intervening prose into invalid JSON.

Query parsing now strips complete reasoning blocks and tries balanced object candidates. It prefers a confidence envelope or flat route over unrelated drafts and wrappers, while preserving existing query normalization, clarification behavior, and distinct `no_json_in_response` / `json_parse_error` diagnostics. Object and price-array extraction share the existing string-aware delimiter balancer.

## Testing

- `npm run ci` on Node 22: lint, strict types, 1,454 web tests and 43 CLI tests passed; 3 existing tests skipped; both production builds passed.
- 19 new regression cases cover reasoning, trailing objects, fences, nested wrappers, legacy routes, null/incomplete answers, escaped delimiters, and failure diagnostics.
- Independent implementation and behavioral-test review passed.

Candidate selection remains heuristic: the first query-shaped candidate wins outside complete `<think>` blocks. This change does not add provider configuration or alter `response_format` behavior.

## Related

References #201. Keeping the issue open for reporter verification.
