### PR TITLE
runtime: slim CLI image dependencies and bound cache retention

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,11 @@ ENV NEXT_PUBLIC_COMMIT_SHA=${COMMIT_SHA}
 RUN npm run build --workspace=@flight-finder/web
 RUN npm run build --workspace=@flight-finder/cli
 
+FROM proddeps AS cliruntime
+COPY scripts/stage-cli-runtime.mjs /stage-cli-runtime.mjs
+COPY --from=builder /app/packages/cli/dist/metafile-esm.json /cli-metafile.json
+RUN node /stage-cli-runtime.mjs /app /cli-runtime /cli-metafile.json
+
 FROM docker.io/library/node:26-alpine AS runner
 RUN apk add --no-cache libc6-compat openssl chromium curl
 ENV NODE_ENV=production
@@ -97,13 +102,12 @@ ENV PATH="/home/node/.npm-global/bin:$PATH"
 
 WORKDIR /app
 COPY --chown=node:node scripts/update-cli.mjs /app/update-cli.mjs
+COPY --chown=node:node scripts/cli-retention.mjs /app/cli-retention.mjs
 COPY --chown=node:node cli-versions.json /app/cli-versions.json
 
 # Standalone server (includes traced node_modules)
 COPY --from=builder --chown=node:node /app/apps/web/.next/standalone ./
-COPY --from=builder --chown=node:node /app/apps/web/.next/static ./.next/static
 COPY --from=builder --chown=node:node /app/apps/web/.next/static ./apps/web/.next/static
-COPY --from=builder /app/apps/web/public ./public
 COPY --from=builder /app/apps/web/public ./apps/web/public
 
 # Prisma schema (the entrypoint db push reads it). The generated client and its
@@ -122,22 +126,15 @@ COPY --from=prismacli --chown=node:node /pcli/node_modules /app/prisma-cli/node_
 # because both come from the same lockfile.
 COPY --from=proddeps --chown=node:node /ext ./node_modules
 
-# Ink terminal UI (flight-finder-tui). The CLI's runtime deps (ink, react,
-# chalk, commander, ink-*, plus their transitives) are not in the lean
-# Next standalone trace, so we ship the full proddeps node_modules under
-# /app/packages/cli/node_modules. Two layers:
-#   1. Root proddeps node_modules — supplies ink, react, etc. (hoisted).
-#   2. Workspace local proddeps node_modules — overrides commander v13 and
-#      chalk v5 that npm could not hoist due to version conflicts at root.
-# Without layer 2 the wrapper picks up commander v2.20.3 which is ESM hostile.
+# Preserve the locked CLI dependency closure at its original hoisted/workspace
+# locations, sharing React identity with Ink and retaining dynamic package assets.
 COPY --from=builder --chown=node:node /app/packages/cli/dist /app/packages/cli/dist
 # Ship the cli package.json next to dist so Node finds "type":"module" when it
 # resolves dist/index.js. Without it Node walks up to the Next standalone
 # /app/package.json (no type field) and reparses every run as ESM, printing the
 # MODULE_TYPELESS_PACKAGE_JSON performance warning.
 COPY --from=builder --chown=node:node /app/packages/cli/package.json /app/packages/cli/package.json
-COPY --from=proddeps --chown=node:node /app/node_modules /app/packages/cli/node_modules
-COPY --from=proddeps --chown=node:node /app/packages/cli/node_modules /app/packages/cli/node_modules
+COPY --from=cliruntime --chown=node:node /cli-runtime /app
 RUN printf '#!/bin/sh\nexec node /app/packages/cli/dist/index.js "$@"\n' > /home/node/.npm-global/bin/flight-finder-tui \
     && chmod +x /home/node/.npm-global/bin/flight-finder-tui \
     && chown node:node /home/node/.npm-global/bin/flight-finder-tui

--- a/apps/web/src/lib/scraper/cli-installer.test.ts
+++ b/apps/web/src/lib/scraper/cli-installer.test.ts
@@ -15,13 +15,17 @@ beforeEach(async () => {
 });
 afterEach(async () => { await rm(root, { recursive: true, force: true }); });
 
-async function npmFixture(fail = false, observed = '0.153.4') {
+async function npmFixture(fail = false, observed = '0.153.4', pause = false) {
   await writeFile(join(root, 'commands', 'npm'), `#!${process.execPath}
 const fs = require('node:fs');
 const path = require('node:path');
 const installation = process.argv[process.argv.indexOf('--prefix') + 1];
 fs.mkdirSync(path.join(installation, 'node_modules', '.bin'), { recursive: true });
 fs.writeFileSync(path.join(installation, 'partial-download'), 'downloaded data');
+if (${pause}) {
+  fs.writeFileSync(${JSON.stringify(join(root, 'started'))}, 'ready');
+  while (!fs.existsSync(${JSON.stringify(join(root, 'release'))})) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+}
 if (${fail}) process.exit(1);
 fs.writeFileSync(path.join(installation, 'node_modules', '.bin', 'codex'), ${JSON.stringify(`#!${process.execPath}\nconsole.log('codex-cli ${observed}');\n`)}, { mode: 0o755 });
 `, { mode: 0o755 });
@@ -79,4 +83,58 @@ it('cleans an unactivated installation when the executable destination cannot be
   expect(await readFile(join(prefix, 'bin', 'codex', 'keep'), 'utf8')).toBe('existing destination');
   expect(await readdir(join(prefix, 'flight-finder-versions'))).toEqual([]);
   expect(await readdir(join(prefix, 'bin'))).toEqual(['codex']);
+});
+
+it('serializes overlapping upgrades and keeps both verified executables runnable', async () => {
+  await npmFixture(false, '0.137.0', true);
+  const first = install('0.137.0');
+  await expect.poll(() => readFile(join(root, 'started'), 'utf8').catch(() => '')).toBe('ready');
+  await npmFixture(false, '0.153.4');
+  const second = install('0.153.4');
+  await writeFile(join(root, 'release'), 'continue');
+  await Promise.all([first, second]);
+  expect((await exec(join(prefix, 'bin', 'codex'), ['--version'])).stdout).toContain('0.153.4');
+  const installations = await readdir(join(prefix, 'flight-finder-versions'));
+  expect(installations).toHaveLength(2);
+  const old = installations.find(name => name.startsWith('codex-0.137.0-'))!;
+  expect((await exec(join(prefix, 'flight-finder-versions', old, 'node_modules/.bin/codex'), ['--version'])).stdout).toContain('0.137.0');
+});
+
+it('startup maintenance retains the newest versions, active CLI and unknown installations', async () => {
+  await npmFixture(); await install();
+  const versions = join(prefix, 'flight-finder-versions');
+  const proc = join(root, 'proc'); await mkdir(proc);
+  const oldTime = Date.now() - 3 * 24 * 60 * 60_000;
+  for (const [name, time] of [['codex-0.1.0-oldold', oldTime], ['codex-0.2.0-backup', oldTime + 1], ['codex-0.3.0-recent', Date.now()]] as const) {
+    await mkdir(join(versions, name));
+    await writeFile(join(versions, name, 'activation.json'), JSON.stringify({ binary: 'codex', version: name.split('-')[1], activatedAt: time }));
+  }
+  await mkdir(join(versions, 'unknown-installation'));
+  const module = resolve(process.cwd(), '../../scripts/cli-retention.mjs');
+  await exec(process.execPath, ['--input-type=module', '-e', `import {mkdir,writeFile} from 'node:fs/promises'; import {retainCliVersions} from ${JSON.stringify(module)}; const proc=${JSON.stringify(proc)}; await mkdir(proc+'/'+process.pid); await writeFile(proc+'/'+process.pid+'/status','PPid: 1'); await mkdir(proc+'/1'); await writeFile(proc+'/1/cmdline','/bin/sh\\0/app/docker-entrypoint.sh\\0'); await retainCliVersions(${JSON.stringify(prefix)}, {procRoot:proc});`]);
+  const retained = await readdir(versions);
+  expect(retained).not.toContain('codex-0.1.0-oldold');
+  expect(retained).toContain('codex-0.3.0-recent');
+  expect(retained).not.toContain('codex-0.2.0-backup');
+  expect(retained).toContain('unknown-installation');
+  expect((await exec(join(prefix, 'bin/codex'), ['--version'])).stdout).toContain('0.153.4');
+});
+
+it('refuses version cleanup when a managed CLI process is still running', async () => {
+  await npmFixture(); await install();
+  const proc = join(root, 'proc', '999999'); await mkdir(proc, { recursive: true });
+  await writeFile(join(proc, 'cmdline'), `node\0${join(prefix, 'bin/codex')}\0`);
+  const before = await readdir(join(prefix, 'flight-finder-versions'));
+  const module = resolve(process.cwd(), '../../scripts/cli-retention.mjs');
+  await expect(exec(process.execPath, ['--input-type=module', '-e', `import {retainCliVersions} from ${JSON.stringify(module)}; await retainCliVersions(${JSON.stringify(prefix)}, {procRoot:${JSON.stringify(join(root, 'proc'))}});`])).rejects.toThrow(/process is running/);
+  expect(await readdir(join(prefix, 'flight-finder-versions'))).toEqual(before);
+});
+
+it('refuses maintenance launched by the running web server', async () => {
+  await npmFixture(); await install();
+  const proc = join(root, 'proc'); await mkdir(proc);
+  const before = await readdir(join(prefix, 'flight-finder-versions'));
+  const module = resolve(process.cwd(), '../../scripts/cli-retention.mjs');
+  await expect(exec(process.execPath, ['--input-type=module', '-e', `import {mkdir,writeFile} from 'node:fs/promises'; import {retainCliVersions} from ${JSON.stringify(module)}; const proc=${JSON.stringify(proc)}; await mkdir(proc+'/'+process.pid); await writeFile(proc+'/'+process.pid+'/status','PPid: 1'); await mkdir(proc+'/1'); await writeFile(proc+'/1/cmdline','node\\0/app/apps/web/server.js\\0'); await retainCliVersions(${JSON.stringify(prefix)}, {procRoot:proc});`])).rejects.toThrow(/startup ancestry/);
+  expect(await readdir(join(prefix, 'flight-finder-versions'))).toEqual(before);
 });

--- a/apps/web/src/lib/scraper/cli-runtime-packaging.test.ts
+++ b/apps/web/src/lib/scraper/cli-runtime-packaging.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, expect, it } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, mkdir, writeFile, readFile, access, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const exec = promisify(execFile);
+let temporary: string;
+let root: string;
+let output: string;
+beforeEach(async () => {
+  temporary = await mkdtemp(join(tmpdir(), 'ff-cli-runtime-'));
+  root = join(temporary, 'installation'); output = join(temporary, 'runtime');
+  await mkdir(join(root, 'packages/cli'), { recursive: true });
+  await packageFixture('node_modules/proper-lockfile', 'proper-lockfile', '4.1.2');
+});
+afterEach(async () => { await rm(temporary, { recursive: true, force: true }); });
+
+async function packageFixture(location: string, name: string, version: string, fields: object = {}) {
+  await mkdir(join(root, location), { recursive: true });
+  await writeFile(join(root, location, 'package.json'), JSON.stringify({ name, version, type: 'module', main: 'index.js', ...fields }));
+  await writeFile(join(root, location, 'index.js'), 'export default {};');
+}
+async function stage(imports: string[]) {
+  const metafile = join(temporary, 'metafile.json');
+  await writeFile(metafile, JSON.stringify({ outputs: { 'index.js': { imports: imports.map(path => ({ path, external: true })) } } }));
+  return exec(process.execPath, [resolve(process.cwd(), '../../scripts/stage-cli-runtime.mjs'), root, output, metafile]);
+}
+
+it('preserves workspace versions, shared React identity and complete runtime data without unrelated packages', async () => {
+  await packageFixture('node_modules/react', 'react', '19.0.0');
+  await packageFixture('node_modules/ink', 'ink', '7.0.0', { peerDependencies: { react: '^19' } });
+  await writeFile(join(root, 'node_modules/ink/index.js'), "import react from 'react'; export default react;");
+  await writeFile(join(root, 'node_modules/ink/runtime-data.bin'), 'dynamic runtime asset');
+  await packageFixture('node_modules/commander', 'commander', '2.0.0');
+  await packageFixture('packages/cli/node_modules/commander', 'commander', '15.0.0');
+  await packageFixture('node_modules/next', 'next', '16.0.0');
+  await stage(['node:fs', 'react/jsx-runtime', 'ink', 'commander']);
+  await writeFile(join(output, 'packages/cli/check.mjs'), "import react from 'react'; import ink from 'ink'; if (react !== ink) throw new Error('Duplicate React');");
+  await exec(process.execPath, [join(output, 'packages/cli/check.mjs')]);
+  expect(JSON.parse(await readFile(join(output, 'packages/cli/node_modules/commander/package.json'), 'utf8')).version).toBe('15.0.0');
+  expect(await readFile(join(output, 'node_modules/ink/runtime-data.bin'), 'utf8')).toBe('dynamic runtime asset');
+  await expect(access(join(output, 'node_modules/next'))).rejects.toThrow();
+  await expect(access(join(output, 'node_modules/commander'))).rejects.toThrow();
+});
+
+it('rejects a missing required dependency while permitting absent optional platform packages', async () => {
+  await packageFixture('node_modules/tool', 'tool', '1.0.0', { dependencies: { required: '1.0.0' }, optionalDependencies: { 'optional-platform': '1.0.0' } });
+  await expect(stage(['tool'])).rejects.toThrow(/required/);
+  await packageFixture('node_modules/required', 'required', '1.0.0');
+  await stage(['tool']);
+  expect(await readFile(join(output, 'node_modules/required/package.json'), 'utf8')).toContain('required');
+});

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,6 +7,11 @@ services:
   db:
     image: docker.io/library/postgres:16-alpine
     restart: unless-stopped
+    logging: &bounded-logs
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "3"
     environment:
       POSTGRES_DB: flight_finder
       POSTGRES_USER: postgres
@@ -24,6 +29,7 @@ services:
   redis:
     image: docker.io/library/redis:7-alpine
     restart: unless-stopped
+    logging: *bounded-logs
     volumes:
       - redisdata:/data
     ports:
@@ -37,6 +43,7 @@ services:
   web:
     image: ${FF_IMAGE:-ghcr.io/affromero/flight-finder}:${FF_IMAGE_TAG:-latest}
     restart: unless-stopped
+    logging: *bounded-logs
     init: true
     ipc: host
     depends_on:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -152,7 +152,7 @@ if [ "$INSTALL_CLI_PROVIDERS" = "true" ]; then
   # runtime "latest" cannot pull an unreviewed release into the image. Bump these
   # deliberately. Override at build/run time with CLAUDE_CODE_VERSION / CODEX_VERSION.
   for cli_provider in claude-code codex; do
-    if ! node /app/update-cli.mjs "$cli_provider"; then
+    if ! node /app/update-cli.mjs "$cli_provider" --maintenance; then
       echo "[setup] WARNING: $cli_provider update failed; recheck its version in Settings"
     fi
   done

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.122.0",
         "@google/generative-ai": "^0.24.1",
-        "openai": "^7.8.0"
+        "openai": "^7.8.0",
+        "proper-lockfile": "4.1.2"
       },
       "devDependencies": {
         "@copilotkit/llmock": "^1.3.1",
@@ -13558,7 +13559,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -14114,7 +14114,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.122.0",
     "@google/generative-ai": "^0.24.1",
-    "openai": "^7.8.0"
+    "openai": "^7.8.0",
+    "proper-lockfile": "4.1.2"
   },
   "devDependencies": {
     "prisma": "7.10.0",

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   dts: false,
   clean: true,
   splitting: false,
+  metafile: true,
   esbuildOptions(options) {
     options.alias = {
       '@': path.resolve(__dirname, '../../apps/web/src'),

--- a/scripts/cli-retention.mjs
+++ b/scripts/cli-retention.mjs
@@ -1,0 +1,72 @@
+import { lstat, readdir, readFile, realpath, rm } from 'node:fs/promises';
+import { basename, join, sep } from 'node:path';
+
+/** Refuse maintenance while any CLI could still need its installation's files. */
+export async function assertManagedClisIdle(prefix, procRoot = '/proc') {
+  const processes = await readdir(procRoot);
+  for (const pid of processes.filter(value => /^\d+$/.test(value) && Number(value) !== process.pid)) {
+    let command;
+    try { command = await readFile(join(procRoot, pid, 'cmdline'), 'utf8'); }
+    catch (error) { if (error.code === 'ENOENT' || error.code === 'ESRCH') continue; throw error; }
+    if (command.split('\0').some(value => value.includes(`${prefix}${sep}`) || ['codex', 'claude'].includes(basename(value)))) {
+      throw new Error('CLI retention refused while a managed CLI process is running');
+    }
+  }
+  // Startup is sequential: only init and the waiting entrypoint may precede us.
+  // The prefix must also be exclusive to this container (deployment verifies it).
+  const ancestors = new Set([String(process.pid)]);
+  let pid = String(process.pid);
+  let entrypoint = false;
+  while (pid !== '1') {
+    const status = await readFile(join(procRoot, pid, 'status'), 'utf8');
+    const parent = status.match(/^PPid:\s+(\d+)$/m)?.[1];
+    if (!parent || parent === '0' || ancestors.has(parent)) throw new Error('CLI retention requires container startup ancestry');
+    const command = (await readFile(join(procRoot, parent, 'cmdline'), 'utf8')).split('\0').filter(Boolean);
+    const shell = ['sh', 'bash', 'ash'].includes(basename(command[0] ?? ''));
+    const startup = shell && command.some(argument => basename(argument) === 'docker-entrypoint.sh');
+    const init = parent === '1' && ['tini', 'docker-init'].includes(basename(command[0] ?? ''));
+    if (!startup && !init) throw new Error('CLI retention requires container startup ancestry');
+    entrypoint ||= startup;
+    ancestors.add(parent);
+    pid = parent;
+  }
+  if (!entrypoint || processes.some(value => /^\d+$/.test(value) && !ancestors.has(value))) {
+    throw new Error('CLI retention requires quiescent container startup');
+  }
+}
+
+/** Caller holds the installation lock. Unknown entries and recent versions stay. */
+export async function retainCliVersions(prefix, { procRoot = '/proc', now = Date.now() } = {}) {
+  await assertManagedClisIdle(prefix, procRoot);
+  const root = join(prefix, 'flight-finder-versions');
+  const active = new Set();
+  for (const binary of ['codex', 'claude']) {
+    try { active.add(await realpath(join(prefix, 'bin', binary))); }
+    catch (error) { if (error.code !== 'ENOENT') throw error; }
+  }
+  const known = [];
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !/^(codex|claude)-\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?-[a-zA-Z0-9]{6}$/.test(entry.name)) continue;
+    const directory = join(root, entry.name);
+    let marker;
+    try {
+      if (!(await lstat(join(directory, 'activation.json'))).isFile()) continue;
+      marker = JSON.parse(await readFile(join(directory, 'activation.json'), 'utf8'));
+    }
+    catch { continue; }
+    if (!['codex', 'claude'].includes(marker.binary) || typeof marker.version !== 'string' || !entry.name.startsWith(`${marker.binary}-${marker.version}-`) || !Number.isFinite(marker.activatedAt)) continue;
+    const information = await lstat(directory);
+    if (!information.isDirectory() || information.isSymbolicLink()) continue;
+    known.push({ directory, binary: marker.binary, activatedAt: marker.activatedAt });
+  }
+  const removed = [];
+  for (const binary of ['codex', 'claude']) {
+    const entries = known.filter(entry => entry.binary === binary).sort((a, b) => b.activatedAt - a.activatedAt);
+    for (const entry of entries.slice(2)) {
+      if (now - entry.activatedAt < 24 * 60 * 60_000 || [...active].some(file => file.startsWith(`${entry.directory}${sep}`))) continue;
+      await rm(entry.directory, { recursive: true });
+      removed.push(entry.directory);
+    }
+  }
+  return removed;
+}

--- a/scripts/stage-cli-runtime.mjs
+++ b/scripts/stage-cli-runtime.mjs
@@ -1,0 +1,82 @@
+import { cp, mkdir, readFile, realpath, stat, writeFile } from 'node:fs/promises';
+import { builtinModules } from 'node:module';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const builtins = new Set(builtinModules.flatMap(name => [name, `node:${name}`]));
+function packageName(specifier) {
+  if (builtins.has(specifier)) return null;
+  const name = specifier.startsWith('@') ? specifier.split('/').slice(0, 2).join('/') : specifier.split('/')[0];
+  if (!/^(?:@[a-z0-9._-]+\/)?[a-z0-9._-]+$/i.test(name) || specifier.startsWith('.')) throw new Error(`Unsupported external import: ${specifier}`);
+  return name;
+}
+
+async function locate(root, from, name) {
+  let directory = from;
+  while (directory === root || directory.startsWith(`${root}${sep}`)) {
+    const candidate = join(directory, 'node_modules', name);
+    try {
+      const actual = await realpath(candidate);
+      if (!actual.startsWith(`${root}${sep}`)) throw new Error(`Dependency escapes installation: ${name}`);
+      const metadata = JSON.parse(await readFile(join(actual, 'package.json'), 'utf8'));
+      if (metadata.name !== name) throw new Error(`Dependency name mismatch: ${name}`);
+      return { directory: actual, metadata };
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
+    if (directory === root) break;
+    directory = dirname(directory);
+  }
+  return null;
+}
+
+/** Copy complete runtime packages, retaining npm's hoisted identity and native/data files. */
+export async function stageCliRuntime(rootPath, outputPath, metafilePath) {
+  const root = await realpath(rootPath);
+  const output = resolve(outputPath);
+  if (output === root || output.startsWith(`${root}${sep}`)) throw new Error('Runtime staging must be outside the dependency installation');
+  const metafile = JSON.parse(await readFile(metafilePath, 'utf8'));
+  const imports = Object.values(metafile.outputs).flatMap(item => item.imports.filter(entry => entry.external).map(entry => entry.path));
+  const queue = imports.map(packageName).filter(Boolean).map(name => ({ name, from: join(root, 'packages/cli'), optional: false }));
+  queue.push({ name: 'proper-lockfile', from: root, optional: false });
+  const copied = new Set();
+  const packages = [];
+  for (const request of queue) {
+    const found = await locate(root, request.from, request.name);
+    if (!found) {
+      if (request.optional) continue;
+      throw new Error(`Required CLI runtime dependency is missing: ${request.name}`);
+    }
+    if (copied.has(found.directory)) continue;
+    copied.add(found.directory);
+    const location = relative(root, found.directory);
+    if (isAbsolute(location) || location.startsWith('..') || !location.split(sep).includes('node_modules')) throw new Error(`Unsupported dependency location: ${location}`);
+    const destination = join(output, location);
+    await mkdir(dirname(destination), { recursive: true });
+    let bytes = 0;
+    await cp(found.directory, destination, { recursive: true, dereference: false, filter: async source => {
+      if (source !== found.directory && source.split(sep).at(-1) === 'node_modules') return false;
+      const info = await stat(source);
+      if (info.isFile()) bytes += info.size;
+      return true;
+    } });
+    packages.push({ name: found.metadata.name, version: found.metadata.version, location, bytes });
+    const required = found.metadata.dependencies ?? {};
+    const optional = found.metadata.optionalDependencies ?? {};
+    const peers = found.metadata.peerDependencies ?? {};
+    for (const name of new Set([...Object.keys(required), ...Object.keys(optional), ...Object.keys(peers)])) {
+      queue.push({ name, from: found.directory, optional: Object.hasOwn(optional, name) || (!Object.hasOwn(required, name) && found.metadata.peerDependenciesMeta?.[name]?.optional === true) });
+    }
+  }
+  packages.sort((a, b) => a.location.localeCompare(b.location));
+  const manifest = { bytes: packages.reduce((sum, item) => sum + item.bytes, 0), packages };
+  await writeFile(join(output, 'cli-runtime-manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [root, output, metafile] = process.argv.slice(2);
+  if (!root || !output || !metafile) throw new Error('Usage: stage-cli-runtime.mjs installation output metafile');
+  const manifest = await stageCliRuntime(root, output, metafile);
+  console.log(`CLI runtime: ${manifest.packages.length} packages, ${manifest.bytes} bytes`);
+}

--- a/scripts/update-cli.mjs
+++ b/scripts/update-cli.mjs
@@ -1,6 +1,8 @@
 import { spawn } from 'node:child_process';
-import { readFile, mkdir, mkdtemp, realpath, symlink, rename, unlink, rm } from 'node:fs/promises';
+import { readFile, mkdir, mkdtemp, realpath, symlink, rename, unlink, rm, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join } from 'node:path';
+import lockfile from 'proper-lockfile';
+import { retainCliVersions } from './cli-retention.mjs';
 
 const versionsPath = new URL('../cli-versions.json', import.meta.url);
 const deployedVersionsPath = new URL('./cli-versions.json', import.meta.url);
@@ -31,6 +33,9 @@ function run(command, args, timeout = 180_000) {
   });
 }
 const binary = join(prefix, 'bin', definition.binary);
+await mkdir(prefix, { recursive: true, mode: 0o700 });
+const release = await lockfile.lock(prefix, { realpath: true, lockfilePath: join(prefix, '.update.lock'), stale: 300_000, update: 10_000, retries: { retries: 120, minTimeout: 250, maxTimeout: 1000 } });
+try {
 const installed = await run(binary, ['--version'], 8000).catch(() => '');
 if (installed.match(/\b\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?\b/)?.[0] === version) {
   console.log(JSON.stringify({ provider, version, changed: false }));
@@ -40,7 +45,7 @@ if (installed.match(/\b\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?\b/)?.[0] === version) {
   const installation = await mkdtemp(join(root, `${definition.binary}-${version}-`));
   let activated = false;
   try {
-  await run('npm', ['install', '--prefix', installation, '--no-save', '--ignore-scripts', '--no-audit', '--no-fund', `${definition.package}@${version}`]);
+  await run('npm', ['install', '--prefix', installation, '--cache', join(installation, 'npm-cache'), '--no-save', '--ignore-scripts', '--no-audit', '--no-fund', `${definition.package}@${version}`]);
   if (provider === 'claude-code') {
     const packageDirectory = join(installation, 'node_modules', '@anthropic-ai', 'claude-code');
     const metadata = JSON.parse(await readFile(join(packageDirectory, 'package.json'), 'utf8'));
@@ -51,6 +56,8 @@ if (installed.match(/\b\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?\b/)?.[0] === version) {
   const target = await realpath(join(installation, 'node_modules', '.bin', definition.binary));
   const observed = await run(target, ['--version'], 8000);
   if (observed.match(/\b\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?\b/)?.[0] !== version) throw new Error('Installed CLI version did not match the requested release');
+  await rm(join(installation, 'npm-cache'), { recursive: true, force: true });
+  await writeFile(join(installation, 'activation.json'), JSON.stringify({ binary: definition.binary, version, activatedAt: Date.now() }), { mode: 0o600 });
   await mkdir(dirname(binary), { recursive: true });
   const temporaryLink = `${binary}.${process.pid}.${Date.now()}`;
   try { await symlink(target, temporaryLink); await rename(temporaryLink, binary); activated = true; }
@@ -60,4 +67,11 @@ if (installed.match(/\b\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?\b/)?.[0] === version) {
     // Only this attempt's staging directory is disposable. Never remove an active or previous installation.
     if (!activated) await rm(installation, { recursive: true, force: true });
   }
+}
+if (process.argv.includes('--maintenance')) {
+  const removed = await retainCliVersions(prefix);
+  if (removed.length) console.error(`Removed ${removed.length} expired CLI installations`);
+}
+} finally {
+  await release();
 }


### PR DESCRIPTION
## Summary

The runtime image copied the entire production dependency tree into the CLI directory. Stage the CLI's locked dependency closure at its original hoisted and workspace paths, preserving shared React identity and complete runtime package assets. Remove duplicate web asset copies.

CLI updates now serialize installation and startup cleanup. Cleanup requires a quiescent container entrypoint, retains active and recent versions, and preserves unknown installations. Compose also bounds service logs to three 20 MB files.

## Testing

- Full `npm run ci`: lint, type checks, 2,607 web tests, 208 CLI tests, and both production builds passed. Existing web exclusions skipped 338 tests.
- Linux amd64 Docker build and full isolated stack smoke passed, including Chromium launch, extraction, database writes, and rental catalog access.
- Actual container startup retention passed. Behavioral tests cover concurrent updates, runtime dependency identity, missing dependencies, retention, and rejection while the web server is running.

The tested image used the working tree before commit. Deployment requires a fresh image carrying the selected merged commit's revision label.
