### PR TITLE
travel: import selected flight, hotel and car links

### DIFF
--- a/.github/workflows/car-tests.yml
+++ b/.github/workflows/car-tests.yml
@@ -21,6 +21,10 @@ jobs:
       - run: npm ci
       - run: npm run db:generate
       - run: npx playwright install chromium --with-deps
+      - name: Verify selected flight and hotel imports
+        run: npm run test --workspace=@flight-finder/web -- src/lib/scraper/imported-flight.browser.test.ts src/lib/hotels/imported-hotel.browser.test.ts
+        env:
+          TRAVEL_BROWSER_TESTS: '1'
       - run: npm run test --workspace=@flight-finder/web -- src/lib/travel/execution.test.ts src/lib/travel/execution.browser.test.ts src/lib/travel/navigation.browser.test.ts src/lib/scraper/browser.test.ts src/lib/cars/browser-context.browser.test.ts src/lib/cars/autoeurope-navigation.browser.test.ts src/lib/cars/discovercars-frame.browser.test.ts src/lib/cars/discovercars-price-lines.browser.test.ts src/lib/cars/discovercars-navigation.browser.test.ts src/lib/cars/discovercars-extras.browser.test.ts src/lib/cars/protection-discovery.browser.test.ts src/lib/cars/controls.browser.test.ts src/lib/cars/search.browser.test.ts
         env:
           TRAVEL_BROWSER_TESTS: '1'

--- a/API.md
+++ b/API.md
@@ -23,6 +23,26 @@ Auth requirements depend on mode and endpoint family:
 
 ## Endpoints
 
+### Import a selected booking link
+
+`POST /api/travel/import` accepts JSON `{ "kind": "flights", "url": "https://..." }`.
+`kind` also accepts `hotels` and `cars`. It returns an editable `flight`, `hotel`,
+or `car` draft plus the normalized `url`. It does not start a search or create a
+tracker. Hotel and car imports require the same self-hosted access as their
+search endpoints.
+
+Supported links are Google Flights selected booking pages, Google Hotels
+properties, Booking.com hotel pages, DiscoverCars offers, and Auto Europe
+options pages. Short links and reservation confirmations are rejected.
+
+Submit the imported `sourceUrl` with the existing preview/search request after
+reviewing the details. Flight imports support one adult and preserve all selected
+segments, dates and cabin; pass `sourceUrl` again when creating the query. Initial
+flight snapshots come from the server scrape. Hotel imports preserve the property
+and require guest and room review. Car imports require catalog locations and
+driver details; tracking uses `mode: "contract"` and fresh contract matching on
+later checks. Expired or changed selections never become broader searches.
+
 ### Parse a flight query
 
 Converts natural language into structured flight data using your configured LLM.

--- a/apps/web/messages/de/common.json
+++ b/apps/web/messages/de/common.json
@@ -1,5 +1,7 @@
 {
   "LinkImport": {
+    "examples": "Beispiele für Linkformate",
+    "examplesHelp": "Diese Beispiele sind gekürzt. Kopiere die vollständige Adresse, nachdem du deinen Flug, dein Hotel oder deinen Mietwagen ausgewählt hast.",
     "confirmHotel": "Ich habe Reisedaten, Gäste und Zimmeraufteilung geprüft. Diese Angaben können im Link fehlen.",
     "label": "Schon ausgewählt? Link einfügen",
     "flights": "Ausgewählte Buchungslinks von Google Flights. Ein Erwachsener, Hinflug oder Hin- und Rückflug.",

--- a/apps/web/messages/de/common.json
+++ b/apps/web/messages/de/common.json
@@ -1,4 +1,17 @@
 {
+  "LinkImport": {
+    "confirmHotel": "Ich habe Reisedaten, Gäste und Zimmeraufteilung geprüft. Diese Angaben können im Link fehlen.",
+    "label": "Schon ausgewählt? Link einfügen",
+    "flights": "Ausgewählte Buchungslinks von Google Flights. Ein Erwachsener, Hinflug oder Hin- und Rückflug.",
+    "hotels": "Hotellinks von Google Hotels oder Booking.com. Prüfe Reisedaten, Gäste und Zimmer.",
+    "cars": "Angebotslinks von DiscoverCars oder Optionslinks von Auto Europe. Prüfe Orte, Zeiten und Fahrerdaten. Abgelaufene Links können nicht importiert werden.",
+    "import": "Link importieren",
+    "loading": "Link wird gelesen…",
+    "failed": "Dieser Link konnte nicht importiert werden",
+    "review": "Prüfe die importierte Auswahl und ergänze fehlende Angaben vor der Suche. Die Preisverfolgung beginnt erst nach der Auswahl eines geprüften Ergebnisses.",
+    "selection": "Importierte Auswahl öffnen",
+    "remove": "Link entfernen"
+  },
   "common": {
     "appName": "Flight Finder",
     "tagline": "Die Preisspur, die Airlines dir nicht zeigen"

--- a/apps/web/messages/en/common.json
+++ b/apps/web/messages/en/common.json
@@ -1,4 +1,17 @@
 {
+  "LinkImport": {
+    "confirmHotel": "I checked the dates, guests and room allocation. These may be missing from the link.",
+    "label": "Already picked one? Paste its link",
+    "flights": "Google Flights selected booking links. One adult, one-way or round trip.",
+    "hotels": "Google Hotels or Booking.com property links. Review the dates, guests and rooms before searching.",
+    "cars": "DiscoverCars offer or Auto Europe options links. Review the locations, dates and driver details. Expired links cannot be imported.",
+    "import": "Import link",
+    "loading": "Reading link…",
+    "failed": "Could not import this link",
+    "review": "Review the imported selection and complete any missing details before searching. Nothing is tracked until you select a verified result.",
+    "selection": "Open imported selection",
+    "remove": "Remove link"
+  },
   "common": {
     "appName": "Flight Finder",
     "tagline": "The price trail airlines don't show you"

--- a/apps/web/messages/en/common.json
+++ b/apps/web/messages/en/common.json
@@ -1,5 +1,7 @@
 {
   "LinkImport": {
+    "examples": "Example link formats",
+    "examplesHelp": "These examples are shortened. Copy the full address after selecting your flight, hotel or rental.",
     "confirmHotel": "I checked the dates, guests and room allocation. These may be missing from the link.",
     "label": "Already picked one? Paste its link",
     "flights": "Google Flights selected booking links. One adult, one-way or round trip.",

--- a/apps/web/messages/es/common.json
+++ b/apps/web/messages/es/common.json
@@ -1,4 +1,17 @@
 {
+  "LinkImport": {
+    "confirmHotel": "Revisé las fechas, los huéspedes y la distribución de habitaciones. Estos datos pueden faltar en el enlace.",
+    "label": "¿Ya elegiste? Pega el enlace",
+    "flights": "Enlaces de reserva seleccionada de Google Flights. Un adulto, solo ida o ida y vuelta.",
+    "hotels": "Enlaces de hoteles de Google Hotels o Booking.com. Revisa las fechas, los huéspedes y las habitaciones.",
+    "cars": "Enlaces de ofertas de DiscoverCars u opciones de Auto Europe. Revisa los lugares, las fechas y los datos del conductor. Los enlaces vencidos no se pueden importar.",
+    "import": "Importar enlace",
+    "loading": "Leyendo enlace…",
+    "failed": "No se pudo importar el enlace",
+    "review": "Revisa la selección importada y completa los datos que faltan antes de buscar. El seguimiento empieza cuando eliges un resultado verificado.",
+    "selection": "Abrir selección importada",
+    "remove": "Quitar enlace"
+  },
   "common": {
     "appName": "Flight Finder",
     "tagline": "El rastro de precios que las aerolíneas no te muestran"

--- a/apps/web/messages/es/common.json
+++ b/apps/web/messages/es/common.json
@@ -1,5 +1,7 @@
 {
   "LinkImport": {
+    "examples": "Ejemplos de formatos de enlace",
+    "examplesHelp": "Estos ejemplos están abreviados. Copia la dirección completa después de seleccionar tu vuelo, hotel o coche de alquiler.",
     "confirmHotel": "Revisé las fechas, los huéspedes y la distribución de habitaciones. Estos datos pueden faltar en el enlace.",
     "label": "¿Ya elegiste? Pega el enlace",
     "flights": "Enlaces de reserva seleccionada de Google Flights. Un adulto, solo ida o ida y vuelta.",

--- a/apps/web/messages/fr/common.json
+++ b/apps/web/messages/fr/common.json
@@ -1,4 +1,17 @@
 {
+  "LinkImport": {
+    "confirmHotel": "J’ai vérifié les dates, les voyageurs et la répartition des chambres. Ces informations peuvent manquer dans le lien.",
+    "label": "Vous avez déjà choisi ? Collez le lien",
+    "flights": "Liens de réservation sélectionnée Google Flights. Un adulte, aller simple ou aller-retour.",
+    "hotels": "Liens d’établissement Google Hotels ou Booking.com. Vérifiez les dates, les voyageurs et les chambres.",
+    "cars": "Liens d’offres DiscoverCars ou d’options Auto Europe. Vérifiez les lieux, les dates et le conducteur. Les liens expirés ne peuvent pas être importés.",
+    "import": "Importer le lien",
+    "loading": "Lecture du lien…",
+    "failed": "Impossible d’importer ce lien",
+    "review": "Vérifiez la sélection importée et complétez les informations manquantes avant la recherche. Le suivi commence après la sélection d’un résultat vérifié.",
+    "selection": "Ouvrir la sélection importée",
+    "remove": "Retirer le lien"
+  },
   "common": {
     "appName": "Flight Finder",
     "tagline": "La piste des prix que les compagnies aériennes te cachent"

--- a/apps/web/messages/fr/common.json
+++ b/apps/web/messages/fr/common.json
@@ -1,5 +1,7 @@
 {
   "LinkImport": {
+    "examples": "Exemples de formats de liens",
+    "examplesHelp": "Ces exemples sont abrégés. Copiez l’adresse complète après avoir sélectionné votre vol, hôtel ou voiture de location.",
     "confirmHotel": "J’ai vérifié les dates, les voyageurs et la répartition des chambres. Ces informations peuvent manquer dans le lien.",
     "label": "Vous avez déjà choisi ? Collez le lien",
     "flights": "Liens de réservation sélectionnée Google Flights. Un adulte, aller simple ou aller-retour.",

--- a/apps/web/messages/pt/common.json
+++ b/apps/web/messages/pt/common.json
@@ -1,4 +1,17 @@
 {
+  "LinkImport": {
+    "confirmHotel": "Conferi as datas, os hóspedes e a distribuição dos quartos. Esses dados podem faltar no link.",
+    "label": "Já escolheu? Cole o link",
+    "flights": "Links de reserva selecionada do Google Flights. Um adulto, só ida ou ida e volta.",
+    "hotels": "Links de hotéis do Google Hotels ou Booking.com. Confira as datas, os hóspedes e os quartos.",
+    "cars": "Links de ofertas da DiscoverCars ou de opções da Auto Europe. Confira os locais, as datas e os dados do motorista. Links expirados não podem ser importados.",
+    "import": "Importar link",
+    "loading": "Lendo link…",
+    "failed": "Não foi possível importar este link",
+    "review": "Confira a seleção importada e complete os dados que faltam antes de buscar. O acompanhamento começa quando você escolhe um resultado verificado.",
+    "selection": "Abrir seleção importada",
+    "remove": "Remover link"
+  },
   "common": {
     "appName": "Flight Finder",
     "tagline": "O rastro de preços que as companhias aéreas não mostram"

--- a/apps/web/messages/pt/common.json
+++ b/apps/web/messages/pt/common.json
@@ -1,5 +1,7 @@
 {
   "LinkImport": {
+    "examples": "Exemplos de formatos de links",
+    "examplesHelp": "Estes exemplos estão abreviados. Copie o endereço completo depois de selecionar seu voo, hotel ou carro de aluguel.",
     "confirmHotel": "Conferi as datas, os hóspedes e a distribuição dos quartos. Esses dados podem faltar no link.",
     "label": "Já escolheu? Cole o link",
     "flights": "Links de reserva selecionada do Google Flights. Um adulto, só ida ou ida e volta.",

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -9,6 +9,7 @@ datasource db {
 
 model Query {
   id              String   @id @default(cuid())
+  sourceUrl       String?
   rawInput        String
   origin          String
   originName      String

--- a/apps/web/src/app/api/preview/route.ts
+++ b/apps/web/src/app/api/preview/route.ts
@@ -100,6 +100,7 @@ function toPreviewRequestPayload(body: Record<string, unknown>): PreviewRequestP
     : body.destination ? [{ code: String(body.destination), name: String(body.destinationName || body.destination) }] : [];
 
   return {
+    sourceUrl: typeof body.sourceUrl === 'string' ? body.sourceUrl : undefined,
     dateFrom: String(body.dateFrom || ''),
     dateTo: String(body.dateTo || ''),
     maxPrice: body.maxPrice === undefined || body.maxPrice === null ? null : Number(body.maxPrice),
@@ -219,6 +220,7 @@ async function runPreviewInBackground(
 export async function POST(request: NextRequest) {
   const body = await request.json().catch(() => null);
   if (!body) return apiError('Invalid JSON body', 400);
+  if (body.sourceUrl !== undefined && typeof body.sourceUrl !== 'string') return apiError('Invalid flight link', 400);
 
   const payload = toPreviewRequestPayload(body as Record<string, unknown>);
 

--- a/apps/web/src/app/api/queries/route.test.ts
+++ b/apps/web/src/app/api/queries/route.test.ts
@@ -44,6 +44,8 @@ vi.mock('@/lib/user-auth', () => ({
 }));
 
 import { POST } from './route';
+import { FLIGHT_IMPORT_URL } from '@/test/import-fixtures';
+import { flightLinkQuery } from '@/lib/scraper/flight-link';
 
 function makeRequest(body: unknown, ip = '1.2.3.4'): NextRequest {
   return new NextRequest('http://localhost/api/queries', {
@@ -72,6 +74,19 @@ const validBody = {
 };
 
 describe('POST /api/queries', () => {
+  it('stores an imported itinerary without trusting client-supplied seed prices', async () => {
+    const parsed = flightLinkQuery(FLIGHT_IMPORT_URL);
+    const res = await POST(makeRequest({ ...parsed, rawInput: 'Selected ORD to DUS round trip', routes: [{ origin: 'ORD', destination: 'DUS', originName: 'Chicago', destinationName: 'Dusseldorf', selectedFlights: [{ price: 1, airline: 'Invented', travelDate: parsed.dateFrom, bookingUrl: FLIGHT_IMPORT_URL }] }] }));
+    expect(res.status).toBe(201);
+    expect(mockQueryCreate.mock.calls.at(-1)?.[0].data).toMatchObject({ sourceUrl: FLIGHT_IMPORT_URL, origin: 'ORD', destination: 'DUS', flexibility: 0 });
+    expect(mockSnapshotCreateMany).not.toHaveBeenCalled();
+  });
+  it('rejects changing the return date of an imported itinerary before creating a tracker', async () => {
+    const parsed = flightLinkQuery(FLIGHT_IMPORT_URL);
+    const res = await POST(makeRequest({ ...parsed, dateTo: '2026-10-20', rawInput: 'Selected flight', origin: 'ORD', destination: 'DUS' }));
+    expect(res.status).toBe(400);
+    expect(mockQueryCreate).not.toHaveBeenCalled();
+  });
   it('rejects old split estimates before writing trackers or snapshots', async () => {
     const res = await POST(makeRequest({ ...validBody, routes: [{ ...validBody.routes[0], selectedFlights: [{
       travelDate: '2026-06-15', price: 2991, currency: 'CAD',

--- a/apps/web/src/app/api/queries/route.ts
+++ b/apps/web/src/app/api/queries/route.ts
@@ -12,6 +12,7 @@ import { isValidPriceAmount } from '@/lib/limits';
 import { CABIN_CLASSES, isCabinClass } from '@/lib/cabin-class';
 import { coerceLayovers } from '@/lib/scraper/duration';
 import { isLegacySplitFare, LEGACY_SPLIT_PREVIEW_ERROR } from '@/lib/flight-pricing';
+import { assertFlightLinkSearch, readFlightLink } from '@/lib/scraper/flight-link';
 
 const MAX_ROUTES = 20;
 const MAX_FLIGHTS_PER_ROUTE = 50;
@@ -201,6 +202,19 @@ export async function POST(request: NextRequest) {
     return apiError(`Too many routes: maximum is ${MAX_ROUTES}`, 400);
   }
 
+  let sourceUrl: string | undefined;
+  if (body.sourceUrl !== undefined && body.sourceUrl !== null) {
+    try {
+      sourceUrl = readFlightLink(body.sourceUrl).url;
+      if (routeInputs.length !== 1) throw new Error('An imported itinerary must create exactly one tracker');
+      const route = routeInputs[0]!;
+      assertFlightLinkSearch(sourceUrl, { origin: route.origin, destination: route.destination, dateFrom: route.date ?? dateFrom, dateTo: route.returnDate ?? dateTo, cabinClass: cabinClass ?? 'economy', tripType: tripType ?? 'round_trip', flexibility: Number(flexibility ?? 0) });
+      // Imported prices are recorded only by the server's immediate scrape.
+      // The browser's preview selection is not an authoritative observation.
+      routeInputs = [{ ...route, selectedFlights: [] }];
+    } catch (error) { return apiError(error instanceof Error ? error.message : 'Invalid selected flight link', 400); }
+  }
+
   // Validate all route fields: airport codes, name lengths, per-route flight counts, and flight fields
   for (const route of routeInputs) {
     if (!/^[A-Z]{3}$/.test(route.origin) || !/^[A-Z]{3}$/.test(route.destination)) {
@@ -349,6 +363,7 @@ export async function POST(request: NextRequest) {
     const query = await prisma.query.create({
       data: {
         rawInput,
+        ...(sourceUrl ? { sourceUrl } : {}),
         origin: route.origin,
         originName: route.originName,
         destination: route.destination,

--- a/apps/web/src/app/api/travel/import/route.test.ts
+++ b/apps/web/src/app/api/travel/import/route.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { POST } from './route';
+import { FLIGHT_IMPORT_URL } from '@/test/import-fixtures';
+
+const request = (body: unknown) => new Request('http://localhost/api/travel/import', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+describe('travel link import HTTP boundary', () => {
+  it('returns selected flight details for review', async () => {
+    const response = await POST(request({ kind: 'flights', url: FLIGHT_IMPORT_URL }));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ ok: true, data: { kind: 'flights', flight: { origin: 'ORD', destination: 'DUS', sourceUrl: FLIGHT_IMPORT_URL } } });
+  });
+  it.each([{ kind: 'flights', url: 'https://example.com' }, { kind: 'boats', url: FLIGHT_IMPORT_URL }, { kind: 'flights', url: 123 }, []])('rejects unsupported imports without a success envelope', async body => {
+    const response = await POST(request(body));
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ ok: false });
+  });
+  it('rejects oversized import requests', async () => {
+    const response = await POST(request({ kind: 'flights', url: 'x'.repeat(65536) }));
+    expect(response.status).toBe(413);
+  });
+});

--- a/apps/web/src/app/api/travel/import/route.ts
+++ b/apps/web/src/app/api/travel/import/route.ts
@@ -1,0 +1,22 @@
+import { apiError, apiSuccess } from '@/lib/api-response';
+import { importTravelDraft } from '@/lib/travel/import-draft';
+import { readCarJson } from '@/lib/cars/http';
+import { CarError } from '@/lib/cars/types';
+import { carActor } from '@/lib/cars/access';
+import { hotelActor } from '@/lib/hotels/access';
+import { HotelError } from '@/lib/hotels/domain';
+
+export async function POST(request: Request) {
+  try {
+    const body = await readCarJson(request);
+    if (!body || typeof body !== 'object' || Array.isArray(body)) return apiError('Expected an import request', 400);
+    const { kind, url } = body as Record<string, unknown>;
+    if (kind !== 'flights' && kind !== 'hotels' && kind !== 'cars') return apiError('Choose flights, hotels or cars', 400);
+    if (kind === 'cars') await carActor();
+    if (kind === 'hotels') await hotelActor();
+    // Decoding is local and bounded. No provider request, AI call or job starts here.
+    return apiSuccess(importTravelDraft(url, kind));
+  } catch (error) {
+    return apiError(error instanceof Error ? error.message : 'Could not import this link', error instanceof CarError || error instanceof HotelError ? error.status : 400);
+  }
+}

--- a/apps/web/src/components/ConfirmationCard.tsx
+++ b/apps/web/src/components/ConfirmationCard.tsx
@@ -15,6 +15,7 @@ import {
 import styles from './ConfirmationCard.module.css';
 
 export interface ParsedQuery {
+  sourceUrl?: string;
   origin: string;
   originName: string;
   destination: string;

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -12,6 +12,7 @@ import styles from './SearchBar.module.css';
 import { ClarificationCard } from './ClarificationCard';
 import { ConfirmationCard, type ParsedQuery } from './ConfirmationCard';
 import { FlightPicker, type RouteFlights } from './FlightPicker';
+import { LinkImport } from './travel/LinkImport';
 import { LinkBanner, type CreatedTracker } from './LinkBanner';
 import { ManualEntryForm, type ManualFormValues } from './ManualEntryForm';
 
@@ -392,6 +393,7 @@ export function SearchBar({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           rawInput: manualRawInput || query.trim(),
+          sourceUrl: parsed.sourceUrl,
           dateFrom: parsed.dateFrom,
           dateTo: parsed.dateTo,
           flexibility: parsed.flexibility,
@@ -526,6 +528,12 @@ export function SearchBar({
 
   return (
     <div className={styles.root}>
+      <LinkImport onBusy={setLoading} kind="flights" disabled={loading || previewLoading} value={parsed?.sourceUrl} onClear={() => { setParsed(null); setPreviewRoutes(null); setPreviewRunId(null); clearSavedPreview(storageKey); }} onImport={draft => {
+        if (!draft.flight) return;
+        setParsed(draft.flight); setManualMode(false); setPreviewRoutes(null); setPreviewRunId(null); setCreatedTrackers(null); setAmbiguities([]); setError(null);
+        setQuery(`${draft.flight.origin} to ${draft.flight.destination} ${draft.flight.dateFrom}${draft.flight.tripType === 'round_trip' ? ` returning ${draft.flight.dateTo}` : ''}`);
+        setManualRawInput(''); clearSavedPreview(storageKey);
+      }} />
       {manualMode ? (
         <ManualEntryForm
           onSubmit={(nextParsed, rawInput, formValues) => {

--- a/apps/web/src/components/cars/CarResults.test.tsx
+++ b/apps/web/src/components/cars/CarResults.test.tsx
@@ -25,6 +25,13 @@ beforeEach(() => { sessionStorage.clear(); });
 afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
 
 describe('rental results and honest tracking controls', () => {
+  it('keeps imported rentals on exact contract tracking', () => {
+    const search = { ...carSearchFixture(), sourceUrl: 'https://www.discovercars.com/offer/selected' };
+    render(<Results search={search} />);
+    expect(screen.getByText(en.Cars.contract)).toBeVisible();
+    expect(screen.queryByRole('combobox', { name: en.Cars.mode })).not.toBeInTheDocument();
+    expect(screen.getByText(en.Cars.contractHelp)).toBeVisible();
+  });
   it.each(Object.keys(locales) as (keyof typeof locales)[])('shows estimated selected seats without permitting tracking in %s', async locale => {
     const search = carSearchFixture(), offer = carOfferFixture(), copy = locales[locale].Cars;
     search.extras.childSeats = [{ category: 'child', quantity: 2 }];

--- a/apps/web/src/components/cars/CarResults.tsx
+++ b/apps/web/src/components/cars/CarResults.tsx
@@ -44,7 +44,7 @@ function CarResultsBody({ actorScope, searchId, search, report, status, mutation
   const [reviews, setReviews] = useState<Record<string, string>>({}), reviewed = useRef(reviews);
   const reviewIdentity = (offer: CarOffer) => JSON.stringify(offer);
   const needsReview = Boolean(search.protectionRecheck);
-  const [draft, setDraft] = useState(defaultCarOptionsDraft), [localError, setLocalError] = useState('');
+  const [draft, setDraft] = useState(() => ({ ...defaultCarOptionsDraft, ...(search.sourceUrl ? { mode: 'contract' as const } : {}) })), [localError, setLocalError] = useState('');
   const complete = status === 'success' || status === 'partial', running = status === 'queued' || status === 'running';
   const closingSearch = ['closing', 'close_uncertain', 'closed'].includes(creation.phase) || ['closing', 'close_uncertain', 'closed'].includes(protection.phase);
   const locked = creation.locked || protection.locked || closed || trackingClosed;
@@ -86,7 +86,7 @@ function CarResultsBody({ actorScope, searchId, search, report, status, mutation
     {creation.phase === 'removed' && <Link className={styles.secondary} href="/cars">{t('carsTitle')}</Link>}
     {creation.phase === 'created' && creation.trackerId && <div role="status" className={styles.notice}><h3>{t('created')}</h3><Link className={styles.button} href={`/cars/${encodeURIComponent(creation.trackerId)}`}>{t('openTracker')}</Link></div>}
     {creation.pending && <dl className={styles.terms} aria-label={t('pendingSettings')}><div><dt>{t('selectedOffer')}</dt><dd>{pendingOffer && `${pendingOffer.supplier} · ${pendingOffer.contract.model} · `}{creation.pending.body.offerId}</dd></div><div><dt>{t('mode')}</dt><dd>{t(creation.pending.body.mode)}</dd></div><div><dt>{t('target', { currency: search.currency })}</dt><dd>{creation.pending.body.target ? formatCarMoney(creation.pending.body.target, locale) : t('noTarget')}</dd></div><div><dt>{t('interval')}</dt><dd>{creation.pending.body.scrapeInterval}</dd></div><div><dt>{t('notifyLows')}</dt><dd>{t(creation.pending.body.notifyLows ? 'yes' : 'no')}</dd></div></dl>}
-    {report.offers.length > 0 && <>{!creation.pending && !closingSearch && <CarTrackingOptions value={draft} currency={search.currency} disabled={locked || !complete || mutationsDisabled} invalid={options === null} onChange={setDraft} />}
+    {report.offers.length > 0 && <>{!creation.pending && !closingSearch && <CarTrackingOptions edit={Boolean(search.sourceUrl)} value={draft} currency={search.currency} disabled={locked || !complete || mutationsDisabled} invalid={options === null} onChange={setDraft} />}
       <div className={styles.offers}>{report.offers.map((offer, index) => <CarOfferRow key={offer.id} offer={offer} search={search} assessment={assessments[index]!} disabled={locked || !complete || options === null || mutationsDisabled || (needsReview && reviews[offer.id] !== reviewIdentity(offer))} onTrack={() => void track(offer)}>
         {needsReview ? <CarProtectionReview offer={offer} reviewed={reviews[offer.id] === reviewIdentity(offer)} disabled={locked || !complete || mutationsDisabled} onReview={checked => {
           const next = { ...reviewed.current, [offer.id]: checked ? reviewIdentity(offer) : '' }; reviewed.current = next; setReviews(next);

--- a/apps/web/src/components/cars/CarSearchForm.test.tsx
+++ b/apps/web/src/components/cars/CarSearchForm.test.tsx
@@ -10,11 +10,14 @@ import es from '../../../messages/es/cars.json';
 import pt from '../../../messages/pt/cars.json';
 import fr from '../../../messages/fr/cars.json';
 import de from '../../../messages/de/cars.json';
+import common from '../../../messages/en/common.json';
+import { CAR_IMPORT_URL } from '@/test/import-fixtures';
+import { validateCarParseDraft } from '@/lib/cars/parse-draft';
 
 vi.unmock('next-intl');
 const place: CarLocationChoice = { id: 'ourairports:2434', version: 'a'.repeat(64), name: 'London Heathrow Airport', kind: 'airport', city: 'London', country: 'GB', region: 'England', timeZone: 'Europe/London', latitude: 51.47, longitude: -.45, iata: 'LHR' };
 const response = (data: unknown) => new Response(JSON.stringify({ ok: true, data }));
-const surface = (locale = 'en', messages = en) => <NextIntlClientProvider locale={locale} messages={messages}><CarSearchForm actorScope="alice" defaultCurrency="GBP" defaultSources={['discovercars', 'autoeurope']} options={carFormOptions(locale)} /></NextIntlClientProvider>;
+const surface = (locale = 'en', messages = en) => <NextIntlClientProvider locale={locale} messages={{ ...messages, LinkImport: common.LinkImport }}><CarSearchForm actorScope="alice" defaultCurrency="GBP" defaultSources={['discovercars', 'autoeurope']} options={carFormOptions(locale)} /></NextIntlClientProvider>;
 beforeEach(() => { vi.useFakeTimers(); sessionStorage.clear(); });
 afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
 const settle = async () => { await act(async () => { await vi.advanceTimersByTimeAsync(0); }); };
@@ -32,6 +35,26 @@ async function completeForm(copy = en.Cars.Search) {
 }
 
 describe('independent rental search form', () => {
+  it('imports the selected quote only after review and blocks competing drafts while importing', async () => {
+    const searches: unknown[] = [];
+    let finish!: (value: Response) => void;
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init: RequestInit) => {
+      if (url.startsWith('/api/cars/locations?')) return response([place]);
+      if (url === '/api/travel/import') return new Promise<Response>(resolve => { finish = resolve; });
+      searches.push(JSON.parse(String(init.body)));
+      return response({ id: 'imported-search', status: 'queued', creationKey: new Headers(init.headers).get('Idempotency-Key') });
+    }));
+    render(surface()); await completeForm();
+    fireEvent.change(screen.getByLabelText(common.LinkImport.label), { target: { value: CAR_IMPORT_URL } });
+    fireEvent.click(screen.getByRole('button', { name: common.LinkImport.import })); await settle();
+    expect(screen.getByLabelText(en.Cars.Draft.description)).toBeDisabled();
+    await act(async () => { finish(response({ kind: 'cars', url: CAR_IMPORT_URL, car: validateCarParseDraft({ sources: ['autoeurope'] }) })); });
+    expect(searches).toEqual([]);
+    expect(screen.getByRole('button', { name: en.Cars.Search.search })).toBeDisabled();
+    fireEvent.click(screen.getByLabelText(en.Cars.Draft.confirm));
+    fireEvent.click(screen.getByRole('button', { name: en.Cars.Search.search })); await settle();
+    expect(searches).toEqual([expect.objectContaining({ sourceUrl: CAR_IMPORT_URL, sources: ['autoeurope'] })]);
+  });
   it('applies suggestions only on request, preserves manual facts, and requires review before searching', async () => {
     const searches: unknown[] = [];
     vi.stubGlobal('fetch', vi.fn(async (url: string, init: RequestInit) => {

--- a/apps/web/src/components/cars/CarSearchForm.tsx
+++ b/apps/web/src/components/cars/CarSearchForm.tsx
@@ -14,6 +14,7 @@ import styles from './CarSearchForm.module.css';
 import { CarNaturalLanguage } from './CarNaturalLanguage';
 import type { CarParseDraft, CarDriverDraft } from '@/lib/cars/parse-draft';
 import { formatCarDecimal } from '@/lib/cars/money';
+import { LinkImport } from '../travel/LinkImport';
 
 interface DriverDraft { age: string; licenceYears: string; residenceCountry: string }
 const blankDriver = (): DriverDraft => ({ age: '', licenceYears: '', residenceCountry: '' });
@@ -31,11 +32,13 @@ function CarSearchFormFields({ actorScope, defaultCurrency, defaultSources, opti
   const [transmission, setTransmission] = useState('any'), [minSeats, setMinSeats] = useState('4'), [maxTotal, setMaxTotal] = useState('');
   const [unlimited, setUnlimited] = useState(false), [cancellation, setCancellation] = useState(false), [error, setError] = useState('');
   const [discardConfirmed, setDiscardConfirmed] = useState(false);
+  const [sourceUrl, setSourceUrl] = useState<string>();
+  const [importBusy, setImportBusy] = useState(false);
   const [draftBusy, setDraftBusy] = useState(false), [reviewRequired, setReviewRequired] = useState(false), [reviewed, setReviewed] = useState(false);
   const [draftWarnings, setDraftWarnings] = useState<string[]>([]);
   const [locationDraft, setLocationDraft] = useState({ pickup: '', dropoff: '', pickupRevision: 0, dropoffRevision: 0 });
   const draftCopy = useTranslations('Cars.Draft');
-  const locked = creation.locked || draftBusy;
+  const locked = creation.locked || draftBusy || importBusy;
   function applyDraft(draft: CarParseDraft) {
     if (creation.locked) return;
     const mergeDriver = (previous: DriverDraft, next: CarDriverDraft): DriverDraft => ({ age: next.age === null ? previous.age : String(next.age), licenceYears: next.licenceYears === null ? previous.licenceYears : String(next.licenceYears), residenceCountry: next.residenceCountry ?? previous.residenceCountry });
@@ -75,7 +78,7 @@ function CarSearchFormFields({ actorScope, defaultCurrency, defaultSources, opti
         if (!value.age || !value.licenceYears || !value.residenceCountry) throw new Error(t('driverRequired'));
         return { ...value, age: Number(value.age), licenceYears: Number(value.licenceYears) };
       };
-      const body = { pickup: { id: pickup.id, version: pickup.version }, dropoff: { id: destination.id, version: destination.version }, pickupAt, dropoffAt, driver: confirmedDriver(driver), currency, sources,
+      const body = { ...(sourceUrl ? { sourceUrl } : {}), pickup: { id: pickup.id, version: pickup.version }, dropoff: { id: destination.id, version: destination.version }, pickupAt, dropoffAt, driver: confirmedDriver(driver), currency, sources,
         extras: { childSeats: CHILD_SEAT_CATEGORIES.filter(category => seats[category] > 0).map(category => ({ category, quantity: seats[category] })), additionalDrivers: drivers.map(confirmedDriver), protection: [] },
         filters: { transmission, minSeats: Number(minSeats), unlimitedMileage: unlimited, freeCancellation: cancellation, maxTotal: carMoneyFromDraft(maxTotal, currency, locale) } };
       validateCarSearch({ ...body, pickup: location(pickup), dropoff: location(destination) }, new Date(), { allowUnresolvedProviders: true });
@@ -83,7 +86,8 @@ function CarSearchFormFields({ actorScope, defaultCurrency, defaultSources, opti
     } catch (error) { setError(error instanceof Error ? error.message : t('invalidSearch')); }
   }
   return <section className={styles.root} aria-labelledby="car-search-heading"><div className={styles.heading}><p>{t('independent')}</p><h2 id="car-search-heading">{t('findCar')}</h2><p>{t('intro')}</p></div>
-    <CarNaturalLanguage disabled={creation.locked} onBusy={setDraftBusy} onApply={applyDraft} />
+    <LinkImport onBusy={setImportBusy} kind="cars" disabled={locked} value={sourceUrl} onClear={() => setSourceUrl(undefined)} onImport={draft => { if (draft.car) { applyDraft(draft.car); setSourceUrl(draft.url); } }} />
+    <CarNaturalLanguage disabled={creation.locked || importBusy || Boolean(sourceUrl)} onBusy={setDraftBusy} onApply={applyDraft} />
     <form onInvalidCapture={event => { const details = (event.target as HTMLElement).closest('details'); if (details) details.open = true; }} onSubmit={event => { event.preventDefault(); void submit(); }}>
       {reviewRequired && <div className={styles.notice} role="status"><p>{draftCopy('reviewHelp')}</p>{draftWarnings.length > 0 && <ul>{draftWarnings.map((warning, index) => <li key={index}>{warning}</li>)}</ul>}</div>}
       <fieldset disabled={locked}><legend>{t('journey')}</legend>

--- a/apps/web/src/components/hotels/HotelSearchForm.tsx
+++ b/apps/web/src/components/hotels/HotelSearchForm.tsx
@@ -4,13 +4,18 @@ import { useTranslations } from 'next-intl';
 import { DEFAULT_HOTEL_FILTERS, HOTEL_AMENITIES, HOTEL_SOURCES, type HotelSearch } from '@/lib/hotels/types';
 import { hotelRequest } from './client';
 import styles from './Hotels.module.css';
+import { LinkImport } from '../travel/LinkImport';
 
-export function HotelSearchForm({ busy, onSearch }: { busy: boolean; onSearch: (search: HotelSearch) => void }) {
+export function HotelSearchForm({ busy: externalBusy, onSearch }: { busy: boolean; onSearch: (search: HotelSearch) => void }) {
   const t = useTranslations('Hotels');
+  const [importBusy, setImportBusy] = useState(false);
+  const busy = externalBusy || importBusy;
   const [search, setSearch] = useState<HotelSearch>({ destination: '', dateMode: 'fixed', checkIn: '', checkOut: '', flexibility: 1, minNights: 1, maxNights: 3, rooms: [{ adults: 2, children: [] }], currency: 'USD', sources: [...HOTEL_SOURCES], filters: { ...DEFAULT_HOTEL_FILTERS } });
   const [text, setText] = useState('');
   const [parsing, setParsing] = useState(false);
   const [error, setError] = useState('');
+  const [importReviewed, setImportReviewed] = useState(false);
+  const importCopy = useTranslations('LinkImport');
   const update = <K extends keyof HotelSearch>(key: K, value: HotelSearch[K]) => setSearch((s) => ({ ...s, [key]: value }));
   const filter = <K extends keyof HotelSearch['filters']>(key: K, value: HotelSearch['filters'][K]) => setSearch((s) => ({ ...s, filters: { ...s.filters, [key]: value } }));
   async function parse() {
@@ -19,8 +24,10 @@ export function HotelSearchForm({ busy, onSearch }: { busy: boolean; onSearch: (
     catch (e) { setError(e instanceof Error ? e.message : t('failed')); }
     finally { setParsing(false); }
   }
-  return <form className={styles.form} onSubmit={(e) => { e.preventDefault(); onSearch({ ...search, filters: { ...search.filters, excludedSellers: search.filters.excludedSellers.filter(Boolean) } }); }}>
-    <fieldset disabled={busy || parsing}>
+  return <form className={styles.form} onSubmit={(e) => { e.preventDefault(); if (search.sourceUrl && !importReviewed) return; onSearch({ ...search, filters: { ...search.filters, excludedSellers: search.filters.excludedSellers.filter(Boolean) } }); }}>
+    <LinkImport onBusy={setImportBusy} kind="hotels" disabled={busy || parsing} value={search.sourceUrl} onClear={() => setSearch(previous => { const next = { ...previous }; delete next.sourceUrl; return next; })} onImport={draft => { if (draft.hotel) { setSearch(previous => ({ ...previous, ...draft.hotel })); setImportReviewed(false); } }} />
+    {search.sourceUrl && <label className={styles.field}><input type="checkbox" required disabled={busy || parsing} checked={importReviewed} onChange={event => setImportReviewed(event.target.checked)} />{importCopy('confirmHotel')}</label>}
+    <fieldset disabled={busy || parsing || Boolean(search.sourceUrl)}>
       <legend>{t('findStay')}</legend>
       <label className={styles.field}>{t('describe')}<textarea value={text} onChange={(e) => setText(e.target.value)} placeholder={t('example')} /></label>
       <div className={styles.actions}><button className={styles.secondary} type="button" disabled={!text.trim()} onClick={() => void parse()}>{parsing ? t('parsing') : t('fillDetails')}</button><span className={styles.muted}>{t('reviewDetails')}</span></div>

--- a/apps/web/src/components/hotels/Hotels.test.tsx
+++ b/apps/web/src/components/hotels/Hotels.test.tsx
@@ -20,6 +20,22 @@ beforeEach(() => { push.mockReset(); });
 afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks(); });
 
 describe('Hotel search and tracking', () => {
+  it('reviews an imported property and carries its identity into the search', async () => {
+    const sourceUrl = 'https://www.booking.com/hotel/gb/strandpalace.html';
+    const fetcher = vi.fn().mockImplementation(async (url: string) => url === '/api/travel/import'
+      ? response({ kind: 'hotels', url: sourceUrl, hotel: { ...search, sourceUrl, sources: ['booking'] } })
+      : response({ id: 'imported-search', status: 'unavailable', result: { offers: [], errors: [], completed: 1, total: 1 } }));
+    vi.stubGlobal('fetch', fetcher); render(<HotelSearchExperience />);
+    fireEvent.change(screen.getByLabelText('Already picked one? Paste its link'), { target: { value: sourceUrl } });
+    fireEvent.click(screen.getByRole('button', { name: 'Import link' }));
+    expect(await screen.findByRole('link', { name: 'Open imported selection' })).toHaveAttribute('href', sourceUrl);
+    expect(fetcher.mock.calls.every(([url]) => url === '/api/travel/import')).toBe(true);
+    fireEvent.click(screen.getByLabelText('I checked the dates, guests and room allocation. These may be missing from the link.'));
+    fireEvent.click(screen.getByRole('button', { name: 'Search hotels' }));
+    await screen.findByText(/No offers matched/);
+    const submitted = fetcher.mock.calls.find(([url]) => url === '/api/hotels/search');
+    expect(JSON.parse(submitted![1].body as string)).toMatchObject({ sourceUrl, sources: ['booking'] });
+  });
   it('offers each travel section from an account without marking one as the current page', () => {
     render(<TravelNav />);
     expect(screen.getByRole('link', { name: 'Flights' })).toHaveAttribute('href', '/');

--- a/apps/web/src/components/travel/LinkImport.module.css
+++ b/apps/web/src/components/travel/LinkImport.module.css
@@ -5,3 +5,9 @@
 .root button:disabled { opacity: .5; cursor: default; }
 .help { color: var(--text-secondary); font-size: .875rem; }
 .error { color: var(--price-up); }
+.examples { margin-block: .75rem; font-size: .875rem; }
+.examples > p { margin-block: .5rem; }
+.examples ul { display: grid; gap: .75rem; margin: .5rem 0; padding: 0; list-style: none; }
+.examples li { display: grid; gap: .25rem; min-width: 0; }
+.examples li span { font-weight: 600; }
+.examples code { color: var(--text-secondary); overflow-wrap: anywhere; }

--- a/apps/web/src/components/travel/LinkImport.module.css
+++ b/apps/web/src/components/travel/LinkImport.module.css
@@ -1,0 +1,7 @@
+.root { padding: 1rem; border: 1px solid var(--border); border-radius: 12px; margin-bottom: 1.5rem; }
+.field { display: grid; gap: .5rem; font-weight: 600; }
+.field input { width: 100%; padding: .75rem; border: 1px solid var(--border); border-radius: 6px; background: var(--bg); color: var(--text); font: inherit; }
+.root button { padding: .5rem .9rem; border: 1px solid var(--border); border-radius: 6px; background: var(--surface); color: var(--text); font: inherit; cursor: pointer; }
+.root button:disabled { opacity: .5; cursor: default; }
+.help { color: var(--text-secondary); font-size: .875rem; }
+.error { color: var(--price-up); }

--- a/apps/web/src/components/travel/LinkImport.test.tsx
+++ b/apps/web/src/components/travel/LinkImport.test.tsx
@@ -7,6 +7,24 @@ import { flightLinkQuery } from '@/lib/scraper/flight-link';
 
 afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); });
 describe('pasting a selected booking link', () => {
+  it.each([
+    { kind: 'flights' as const, providers: ['Google Flights'], paths: ['/travel/flights/booking?tfs='] },
+    { kind: 'hotels' as const, providers: ['Google Hotels', 'Booking.com'], paths: ['/travel/hotels/entity/', '/hotel/es/'] },
+    { kind: 'cars' as const, providers: ['DiscoverCars', 'Auto Europe'], paths: ['/offer/', '/en-us/options?rate_reference='] },
+  ])('shows example formats for $kind without importing them', ({ kind, providers, paths }) => {
+    const requests: string[] = [], drafts: unknown[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => { requests.push(url); return new Response('{}'); }));
+    render(<LinkImport kind={kind} disabled={false} onImport={draft => drafts.push(draft)} onClear={() => drafts.splice(0)} />);
+    expect(screen.getByText('Example link formats')).toBeInTheDocument();
+    for (const provider of providers) expect(screen.getByText(provider, { exact: true })).toBeInTheDocument();
+    for (const path of paths) expect(screen.getByText(text => text.startsWith('https://') && text.includes(path))).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toHaveValue('');
+    expect(screen.getByRole('textbox')).toHaveAccessibleDescription(/Example link formats/);
+    expect(screen.getByRole('button', { name: 'Import link' })).toBeDisabled();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(requests).toEqual([]);
+    expect(drafts).toEqual([]);
+  });
   it('imports details for review without creating a tracker or starting a scrape', async () => {
     const drafts: unknown[] = [], requests: string[] = [];
     const result = { kind: 'flights', url: FLIGHT_IMPORT_URL, flight: flightLinkQuery(FLIGHT_IMPORT_URL) };

--- a/apps/web/src/components/travel/LinkImport.test.tsx
+++ b/apps/web/src/components/travel/LinkImport.test.tsx
@@ -1,0 +1,43 @@
+/** @vitest-environment jsdom */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LinkImport } from './LinkImport';
+import { FLIGHT_IMPORT_URL } from '@/test/import-fixtures';
+import { flightLinkQuery } from '@/lib/scraper/flight-link';
+
+afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); });
+describe('pasting a selected booking link', () => {
+  it('imports details for review without creating a tracker or starting a scrape', async () => {
+    const drafts: unknown[] = [], requests: string[] = [];
+    const result = { kind: 'flights', url: FLIGHT_IMPORT_URL, flight: flightLinkQuery(FLIGHT_IMPORT_URL) };
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => { requests.push(url); return new Response(JSON.stringify({ ok: true, data: result })); }));
+    render(<LinkImport kind="flights" disabled={false} onImport={draft => drafts.push(draft)} onClear={() => drafts.splice(0)} />);
+    fireEvent.change(screen.getByLabelText('Already picked one? Paste its link'), { target: { value: FLIGHT_IMPORT_URL } });
+    fireEvent.click(screen.getByRole('button', { name: 'Import link' }));
+    await waitFor(() => expect(drafts).toEqual([result]));
+    expect(requests).toEqual(['/api/travel/import']);
+  });
+  it('surfaces unsupported links without applying a replacement draft', async () => {
+    const drafts: unknown[] = [];
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ ok: false, error: 'This hotel link is not supported' }), { status: 400 })));
+    render(<LinkImport kind="hotels" disabled={false} onImport={draft => drafts.push(draft)} onClear={() => drafts.splice(0)} />);
+    fireEvent.change(screen.getByLabelText('Already picked one? Paste its link'), { target: { value: 'https://example.com/hotel' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Import link' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/not supported/);
+    expect(drafts).toEqual([]);
+    expect(screen.getByRole('button', { name: 'Import link' })).toBeEnabled();
+  });
+  it('releases the form after a stalled import request times out', async () => {
+    vi.useFakeTimers();
+    const drafts: unknown[] = [], busy: boolean[] = [];
+    vi.stubGlobal('fetch', vi.fn((url: string, init: RequestInit) => new Promise((resolve, reject) => { init.signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true }); })));
+    render(<LinkImport kind="cars" disabled={false} onBusy={value => busy.push(value)} onImport={draft => drafts.push(draft)} onClear={() => drafts.splice(0)} />);
+    fireEvent.change(screen.getByLabelText('Already picked one? Paste its link'), { target: { value: 'https://book.autoeurope.com/en-us/options?rate_reference=old' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Import link' }));
+    await act(async () => { await vi.advanceTimersByTimeAsync(15000); });
+    expect(screen.getByRole('alert')).toHaveTextContent(/Could not import/);
+    expect(busy.at(-1)).toBe(false);
+    expect(drafts).toEqual([]);
+    expect(screen.getByRole('button', { name: 'Import link' })).toBeEnabled();
+  });
+});

--- a/apps/web/src/components/travel/LinkImport.tsx
+++ b/apps/web/src/components/travel/LinkImport.tsx
@@ -1,13 +1,26 @@
 'use client';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import type { ImportKind } from '@/lib/travel/import-url';
 import type { TravelImportDraft } from '@/lib/travel/import-draft';
 import { travelRequest } from './client';
 import styles from './LinkImport.module.css';
 
+const examples: Record<ImportKind, { provider: string; url: string }[]> = {
+  flights: [{ provider: 'Google Flights', url: 'https://www.google.com/travel/flights/booking?tfs=…' }],
+  hotels: [
+    { provider: 'Google Hotels', url: 'https://www.google.com/travel/hotels/entity/…' },
+    { provider: 'Booking.com', url: 'https://www.booking.com/hotel/es/….html?checkin=…&checkout=…' },
+  ],
+  cars: [
+    { provider: 'DiscoverCars', url: 'https://www.discovercars.com/offer/…?sq=…' },
+    { provider: 'Auto Europe', url: 'https://book.autoeurope.com/en-us/options?rate_reference=…&…' },
+  ],
+};
+
 export function LinkImport({ kind, disabled, value, onImport, onClear, onBusy }: { kind: ImportKind; disabled: boolean; value?: string; onImport: (draft: TravelImportDraft) => void; onClear: () => void; onBusy?: (busy: boolean) => void }) {
   const t = useTranslations('LinkImport');
+  const helpId = useId(), examplesId = useId();
   const [url, setUrl] = useState(''), [busy, setBusy] = useState(false), [error, setError] = useState('');
   const request = useRef<AbortController | null>(null);
   useEffect(() => () => { request.current?.abort(); request.current = null; onBusy?.(false); }, [onBusy]);
@@ -23,8 +36,13 @@ export function LinkImport({ kind, disabled, value, onImport, onClear, onBusy }:
     finally { clearTimeout(timer); if (request.current === controller) { setBusy(false); onBusy?.(false); request.current = null; } }
   }
   return <section className={styles.root}>
-    <label className={styles.field}>{t('label')}<input type="text" inputMode="url" value={url} maxLength={16000} disabled={disabled || busy} placeholder="https://…" onChange={event => { setUrl(event.target.value); setError(''); }} /></label>
-    <p className={styles.help}>{t(kind)}</p>
+    <label className={styles.field}>{t('label')}<input type="text" inputMode="url" value={url} maxLength={16000} disabled={disabled || busy} placeholder="https://…" aria-describedby={`${helpId} ${examplesId}`} onChange={event => { setUrl(event.target.value); setError(''); }} /></label>
+    <p id={helpId} className={styles.help}>{t(kind)}</p>
+    <div id={examplesId} className={styles.examples}>
+      <p>{t('examples')}</p>
+      <ul>{examples[kind].map(example => <li key={example.provider}><span>{example.provider}</span><code>{example.url}</code></li>)}</ul>
+      <p className={styles.help}>{t('examplesHelp')}</p>
+    </div>
     <button type="button" disabled={disabled || busy || !url.trim()} onClick={() => void load()}>{t(busy ? 'loading' : 'import')}</button>
     {error && <p role="alert" className={styles.error}>{error}</p>}
     {value && <div role="status"><p>{t('review')}</p><a href={value} target="_blank" rel="noopener noreferrer">{t('selection')}</a> <button type="button" disabled={disabled || busy} onClick={() => { onClear(); setUrl(''); }}>{t('remove')}</button></div>}

--- a/apps/web/src/components/travel/LinkImport.tsx
+++ b/apps/web/src/components/travel/LinkImport.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import type { ImportKind } from '@/lib/travel/import-url';
+import type { TravelImportDraft } from '@/lib/travel/import-draft';
+import { travelRequest } from './client';
+import styles from './LinkImport.module.css';
+
+export function LinkImport({ kind, disabled, value, onImport, onClear, onBusy }: { kind: ImportKind; disabled: boolean; value?: string; onImport: (draft: TravelImportDraft) => void; onClear: () => void; onBusy?: (busy: boolean) => void }) {
+  const t = useTranslations('LinkImport');
+  const [url, setUrl] = useState(''), [busy, setBusy] = useState(false), [error, setError] = useState('');
+  const request = useRef<AbortController | null>(null);
+  useEffect(() => () => { request.current?.abort(); request.current = null; onBusy?.(false); }, [onBusy]);
+  async function load() {
+    if (disabled || busy) return;
+    const controller = new AbortController(); request.current = controller;
+    const timer = setTimeout(() => controller.abort(), 15000);
+    setBusy(true); onBusy?.(true); setError('');
+    try {
+      const result = await travelRequest<TravelImportDraft>('/api/travel/import', { method: 'POST', body: JSON.stringify({ kind, url }), signal: controller.signal });
+      if (!controller.signal.aborted) onImport(result);
+    } catch (error) { if (request.current === controller) setError(controller.signal.aborted ? t('failed') : error instanceof Error ? error.message : t('failed')); }
+    finally { clearTimeout(timer); if (request.current === controller) { setBusy(false); onBusy?.(false); request.current = null; } }
+  }
+  return <section className={styles.root}>
+    <label className={styles.field}>{t('label')}<input type="text" inputMode="url" value={url} maxLength={16000} disabled={disabled || busy} placeholder="https://…" onChange={event => { setUrl(event.target.value); setError(''); }} /></label>
+    <p className={styles.help}>{t(kind)}</p>
+    <button type="button" disabled={disabled || busy || !url.trim()} onClick={() => void load()}>{t(busy ? 'loading' : 'import')}</button>
+    {error && <p role="alert" className={styles.error}>{error}</p>}
+    {value && <div role="status"><p>{t('review')}</p><a href={value} target="_blank" rel="noopener noreferrer">{t('selection')}</a> <button type="button" disabled={disabled || busy} onClick={() => { onClear(); setUrl(''); }}>{t('remove')}</button></div>}
+  </section>;
+}

--- a/apps/web/src/lib/cars/import-url.ts
+++ b/apps/web/src/lib/cars/import-url.ts
@@ -1,0 +1,7 @@
+import { optionalImportUrl } from '../travel/import-url';
+import { CarError } from './types';
+
+export function carImportUrl(raw: unknown, sources: readonly string[]): string | undefined {
+  try { return optionalImportUrl(raw, 'cars', sources); }
+  catch (error) { throw new CarError(error instanceof Error ? error.message : 'Invalid rental link'); }
+}

--- a/apps/web/src/lib/cars/imported-car.live.test.ts
+++ b/apps/web/src/lib/cars/imported-car.live.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { launchBrowser } from '../scraper/browser';
+import { TravelExecution, withTravelExecution, closeTravelBrowser } from '../travel/execution';
+import { createCarBrowserContext } from './browser-context';
+import { navigateAutoEuropeSearch } from './autoeurope-navigation';
+import { navigateDiscoverCarsSearch } from './discovercars-navigation';
+import { validateCarSearch } from './validation';
+import { searchCars } from './search';
+import { validateCarReport } from './report';
+import { carProtectionQuoteIdentity } from './protection-discovery';
+import { resolveCarProviderLocations } from './location-resolution';
+import { getCarCatalogPlace } from './locations';
+
+describe.skipIf(process.env.TRAVEL_LIVE_TESTS !== '1')('selected quotes on live rental providers', () => {
+  it.each(['autoeurope', 'discovercars'] as const)('preserves a selected %s quote and surfaces unverified terms', async source => {
+    const place = await getCarCatalogPlace('ourairports:2434');
+    const location = { name: place.name, country: place.country, timeZone: place.timeZone, providerIds: {}, catalog: { id: place.id, version: place.version } };
+    const search = validateCarSearch({ pickup: location, dropoff: location, pickupAt: { date: '2026-10-15', time: '12:00' }, dropoffAt: { date: '2026-10-18', time: '12:00' }, driver: { age: 35, licenceYears: 5, residenceCountry: 'GB' }, currency: 'GBP', sources: [source] }, new Date(), { allowUnresolvedProviders: true });
+    await withTravelExecution(new TravelExecution({ jobId: 'live-link-import', generation: 1, resource: 'browser' }), async () => {
+      const browser = await launchBrowser();
+      let sourceUrl: string | undefined;
+      try {
+        const context = await createCarBrowserContext(browser, search), page = await context.newPage();
+        const resolved = await resolveCarProviderLocations(page, search, source);
+        const discovery = source === 'autoeurope' ? await navigateAutoEuropeSearch(page, resolved) : await navigateDiscoverCarsSearch(page, resolved);
+        sourceUrl = discovery.links[0];
+      } finally { await closeTravelBrowser(browser); }
+      if (!sourceUrl) throw new Error('The provider did not return a quote to import');
+      const report = await searchCars({ ...search, sourceUrl });
+      expect(report.errors).toEqual([]);
+      const observations = [...report.offers, ...report.candidates];
+      expect(observations).toHaveLength(1);
+      expect(carProtectionQuoteIdentity(observations[0]!.bookingUrl, source)).toBe(carProtectionQuoteIdentity(sourceUrl, source));
+      for (const candidate of report.candidates) {
+        expect(report.offers).toHaveLength(0);
+        expect(candidate.reasons.length).toBeGreaterThan(0);
+        expect(candidate.advertisedTotal?.status ?? 'estimated').toBe('estimated');
+      }
+      expect(validateCarReport(report, [source])).toEqual(report);
+    });
+  }, 240000);
+});

--- a/apps/web/src/lib/cars/public-input.ts
+++ b/apps/web/src/lib/cars/public-input.ts
@@ -1,4 +1,5 @@
 import { CarError } from './types';
+import { carImportUrl } from './import-url';
 import { currencyPrecision } from './money';
 import { validateCarProviders } from './preferences';
 import { carRecord, carText, validateCarDriver, validateCarExtras, validateCarFilters, validateCarLocalDateTime } from './validation';
@@ -29,12 +30,14 @@ function extras(raw: unknown) {
 
 /** Syntax and stable intent only. Catalog geography and date eligibility belong to the server. */
 export function normalizeCarSearchInput(raw: unknown) {
-  const value = carInputFields(raw, ['pickup', 'dropoff', 'pickupAt', 'dropoffAt', 'driver', 'currency', 'sources', 'extras', 'filters'], 'Unsupported rental search field');
+  const value = carInputFields(raw, ['pickup', 'dropoff', 'pickupAt', 'dropoffAt', 'driver', 'currency', 'sources', 'extras', 'filters', 'sourceUrl'], 'Unsupported rental search field');
   const currency = carText(value.currency, 3, 'currency').toUpperCase();
   currencyPrecision(currency);
   const filters = carInputFields(value.filters ?? {}, ['transmission', 'minSeats', 'unlimitedMileage', 'freeCancellation', 'maxTotal']);
   if (filters.maxTotal != null) carInputFields(filters.maxTotal, ['currency', 'minor']);
+  const sourceUrl = carImportUrl(value.sourceUrl, validateCarProviders(value.sources));
   return {
+    ...(sourceUrl ? { sourceUrl } : {}),
     pickup: catalogLocation(value.pickup), dropoff: catalogLocation(value.dropoff),
     pickupAt: validateCarLocalDateTime(carInputFields(value.pickupAt, ['date', 'time'], 'Enter date and local time; the station timezone is server-managed')),
     dropoffAt: validateCarLocalDateTime(carInputFields(value.dropoffAt, ['date', 'time'], 'Enter date and local time; the station timezone is server-managed')),

--- a/apps/web/src/lib/cars/report.test.ts
+++ b/apps/web/src/lib/cars/report.test.ts
@@ -3,6 +3,11 @@ import { carOfferFixture, carReportFixture, carSearchFixture } from '@/test/car-
 import { validateCarReport } from './report';
 
 describe('rental report validation at persistence boundaries', () => {
+  it('preserves the one-offer scope of an imported rental', () => {
+    const report = carReportFixture();
+    report.providers[0]!.limit = 1;
+    expect(validateCarReport(report, carSearchFixture().sources)).toEqual(report);
+  });
   it('retains verified quotes and coherent progress while removing unrecognized fields', () => {
     const report = carReportFixture();
     expect(validateCarReport({ ...report, unsafePayload: 'discard' }, carSearchFixture().sources)).toEqual(report);

--- a/apps/web/src/lib/cars/report.ts
+++ b/apps/web/src/lib/cars/report.ts
@@ -34,10 +34,11 @@ export function validateCarReport(raw: unknown, sources: CarSource[], now = new 
     const p = carRecord(value), source = provider(p.source, sources);
     if (source !== sources[index]) throw new CarError('Rental report changed provider preference order');
     const status = (['running', 'complete', 'partial', 'failed', 'timed_out', 'blocked', 'cancelled'] as const).find(status => status === p.status);
-    if (!status || p.limit !== 8 || typeof p.truncated !== 'boolean') throw new CarError('Invalid rental provider progress');
-    const checked = carInteger(p.checked, 0, 8, 'Checked offers'), discoveredVisible = carInteger(p.discoveredVisible, checked, 10000, 'Visible offers');
-    if (p.truncated !== (discoveredVisible > 8)) throw new CarError('Rental report has inconsistent scan limits');
-    return { source, status, checked, discoveredVisible, limit: 8, truncated: p.truncated };
+    if (!status || (p.limit !== 8 && p.limit !== 1) || typeof p.truncated !== 'boolean') throw new CarError('Invalid rental provider progress');
+    const limit = p.limit;
+    const checked = carInteger(p.checked, 0, limit, 'Checked offers'), discoveredVisible = carInteger(p.discoveredVisible, checked, 10000, 'Visible offers');
+    if (p.truncated !== (discoveredVisible > limit)) throw new CarError('Rental report has inconsistent scan limits');
+    return { source, status, checked, discoveredVisible, limit, truncated: p.truncated };
   });
   const offers = list(r.offers, 16).map(value => validateCarOffer(value, now));
   if (new Set(offers.map(offer => offer.id)).size !== offers.length) throw new CarError('Rental report contains duplicate quotes');

--- a/apps/web/src/lib/cars/search.browser.test.ts
+++ b/apps/web/src/lib/cars/search.browser.test.ts
@@ -186,7 +186,23 @@ describe.skipIf(process.env.TRAVEL_BROWSER_TESTS !== '1')('bounded rental provid
     }
   });
   afterAll(async () => { if (server) { server.closeAllConnections(); await new Promise<void>(resolve => server.close(() => resolve())); } await prisma.$disconnect(); });
-  const run = (options: Parameters<typeof searchCars>[1] = {}, sources = criteria().sources) => withTravelExecution(new TravelExecution({ jobId: 'browser-fixture', generation: 1, resource: 'browser' }), () => searchCars({ ...criteria(), sources }, options));
+  const run = (options: Parameters<typeof searchCars>[1] = {}, sources = criteria().sources, sourceUrl?: string) => withTravelExecution(new TravelExecution({ jobId: 'browser-fixture', generation: 1, resource: 'browser' }), () => searchCars({ ...criteria(), sources, ...(sourceUrl ? { sourceUrl } : {}) }, options));
+
+  it('checks only the imported offer even when fresh discovery lists another quote', async () => {
+    const sourceUrl = `https://book.autoeurope.com${routeUrl('options', 'selected')}`;
+    const result = await run({}, ['autoeurope'], sourceUrl);
+    expect(result).toMatchObject({ offers: [{ total: { value: { minor: 4965 } } }], providers: [{ checked: 1, limit: 1, truncated: false }] });
+    expect(result.offers[0]?.bookingUrl).toContain('rate_reference=selected');
+    expect(validateCarReport(result, ['autoeurope'])).toEqual(result);
+    expect(requested.some(path => path.includes('/options?rate_reference=good'))).toBe(false);
+  }, 30000);
+
+  it('surfaces an expired imported quote without substituting an available discovery result', async () => {
+    const result = await run({}, ['autoeurope'], `https://book.autoeurope.com${routeUrl('options', 'broken')}`);
+    expect(result.offers).toEqual([]);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(requested.some(path => path.includes('/options?rate_reference=good'))).toBe(false);
+  }, 30000);
 
   it('publishes base quotes before protection and preserves observed choice identities through final validation', async () => {
     protectionMode = 'available'; let sawBaseFirst = false;

--- a/apps/web/src/lib/cars/search.ts
+++ b/apps/web/src/lib/cars/search.ts
@@ -17,6 +17,7 @@ import { discoverDiscoverCarsProtection } from './discovercars-protection';
 import { carProtectionQuoteIdentity, validateCarProtectionDiscovery } from './protection-discovery';
 import { CarError, type CarContractSelection, type CarOffer, type CarProviderProgress, type CarSearch, type CarSearchReport, type CarSource } from './types';
 import { createCarBrowserContext, withCarQuoteContext } from './browser-context';
+import { verifyCarProviderContext } from './provider-context';
 
 export class CarSearchCleanupError extends Error {
   constructor(readonly report: CarSearchReport, cause: unknown) {
@@ -117,7 +118,11 @@ async function inspectProvider(source: CarSource, search: CarSearch, report: Car
     }
     Object.assign(search, { pickup: resolved.pickup, dropoff: resolved.dropoff });
     search = singleSource;
-    const discovery = source === 'discovercars' ? await navigateDiscoverCarsSearch(searchPage, search) : await navigateAutoEuropeSearch(searchPage, search);
+    let discovery = source === 'discovercars' ? await navigateDiscoverCarsSearch(searchPage, search) : await navigateAutoEuropeSearch(searchPage, search);
+    if (search.sourceUrl) {
+      verifyCarProviderContext(search.sourceUrl, source, search);
+      discovery = { links: [search.sourceUrl], discoveredVisible: 1, limit: 1, truncated: false };
+    }
     Object.assign(progress, { discoveredVisible: discovery.discoveredVisible, limit: discovery.limit, truncated: discovery.truncated });
     await publishProgress(report, options.onProgress, [execution.signal]);
     const detail = await context.newPage();
@@ -129,6 +134,7 @@ async function inspectProvider(source: CarSource, search: CarSearch, report: Car
       let protectionOffer: CarOffer | undefined;
       try {
         const observation = await captureRequestedOffer(source, detail, url, search, searchPage);
+        if (search.sourceUrl && carProtectionQuoteIdentity(search.sourceUrl, source) !== carProtectionQuoteIdentity(observation.bookingUrl, source)) throw new CarError('The provider changed the imported rental; no substitute offer was used');
         if ('contract' in observation) report.offers.push(observation);
         else report.candidates.push(observation);
         if ('contract' in observation && options.discoverProtection && search.extras.protection.length === 0 && !options.selection) {

--- a/apps/web/src/lib/cars/selection.test.ts
+++ b/apps/web/src/lib/cars/selection.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it } from 'vitest';
 import { carContractHash, carTrackerSearch, selectCarObservation } from './selection';
 import { validateCarSearch } from './validation';
 import type { CarEvidence, CarOffer, CarSearchReport } from './types';
+import { CAR_IMPORT_URL } from '@/test/import-fixtures';
+
+it('refreshes an imported rental using its verified contract instead of an expiring offer link', () => {
+  const tracking = carTrackerSearch({ ...search, sourceUrl: CAR_IMPORT_URL });
+  expect(tracking.sourceUrl).toBeUndefined();
+  expect(tracking.pickupAt).toEqual(search.pickupAt);
+  expect(tracking.driver).toEqual(search.driver);
+});
 
 const now = new Date('2026-09-06T12:01:00Z');
 const location = { name: 'Example Airport', country: 'GB', timeZone: 'Europe/London', providerIds: { discovercars: '1712' } };

--- a/apps/web/src/lib/cars/selection.ts
+++ b/apps/web/src/lib/cars/selection.ts
@@ -13,6 +13,7 @@ export function carContractHash(contract: unknown): string {
 export function carTrackerSearch(search: CarSearch): CarSearch {
   const tracking = { ...search, filters: { ...search.filters, maxTotal: null } };
   delete tracking.protectionRecheck;
+  delete tracking.sourceUrl;
   return tracking;
 }
 

--- a/apps/web/src/lib/cars/store.integration.test.ts
+++ b/apps/web/src/lib/cars/store.integration.test.ts
@@ -12,6 +12,18 @@ import { listCarSearchPage } from './search-list';
 import { closeCarSearchTracking, createCarProtectionRecheck } from './store';
 
 describe.skipIf(process.env.CAR_STORE_INTEGRATION_TESTS !== '1')('car ownership and persistence against isolated PostgreSQL', () => {
+  it('persists imported rentals as exact contracts and refreshes without their expiring link', async () => {
+    const sourceUrl = 'https://www.discovercars.com/offer/12345678-abcd-abcd-abcd-123456789abc-ab12?sq=e30%3D';
+    const search = { ...criteria(), sourceUrl, sources: ['discovercars'] }, value = offer();
+    const run = await prisma.carSearchRun.create({ data: { userId: owner.userId, request: carJson(search), result: carJson(carReportFixture([value])), status: 'success', createdAt: new Date(value.observedAt), completedAt: new Date() } });
+    await expect(createCarTracker({ searchId: run.id, offerId: value.id, mode: 'best' }, owner)).rejects.toMatchObject({ status: 400 });
+    const tracked = await createCarTracker({ searchId: run.id, offerId: value.id, mode: 'contract' }, owner);
+    expect(tracked.mode).toBe('contract');
+    expect(tracked.selection).toMatchObject({ source: 'discovercars', contractHash: carContractHash(value.contract) });
+    expect(tracked.search).not.toHaveProperty('sourceUrl');
+    const refresh = await prisma.carSearchRun.findFirstOrThrow({ where: { trackerId: tracked.id } });
+    expect(refresh.request).not.toHaveProperty('sourceUrl');
+  });
   let owner: CarActor, other: CarActor;
   const leases: TravelLeaseToken[] = [];
   beforeAll(() => {

--- a/apps/web/src/lib/cars/store.ts
+++ b/apps/web/src/lib/cars/store.ts
@@ -178,6 +178,7 @@ export async function createCarTracker(raw: unknown, actor: CarActor, requestKey
     const assessment = assessCarPrice(offer, search);
     if (!assessment.eligible) throw new CarError(`This quote cannot be tracked: ${assessment.reasons.join('; ')}`, 409);
     const options = validateCarOptions(intent.options, search.currency);
+    if (search.sourceUrl && options.mode !== 'contract') throw new CarError('Track the selected contract for an imported rental', 400);
     const selection = options.mode === 'contract' ? { source: offer.contract.source, contractHash: carContractHash(offer.contract) } : null;
     const trackingSearch = carTrackerSearch(search);
     const tracker = await tx.carTracker.create({ data: {

--- a/apps/web/src/lib/cars/types.ts
+++ b/apps/web/src/lib/cars/types.ts
@@ -29,6 +29,7 @@ export interface CarExtras {
   protection: { source: CarSource; productId: string }[];
 }
 export interface CarSearch {
+  sourceUrl?: string;
   /** Server-authored binding for a fresh quote, never ordinary search input. */
   protectionRecheck?: { searchId: string; offerId: string; choiceId: string; baseContractHash: string; baseCoverageTerms: string };
   pickup: CarLocation;

--- a/apps/web/src/lib/cars/validation.ts
+++ b/apps/web/src/lib/cars/validation.ts
@@ -1,4 +1,5 @@
 import { Temporal } from '@js-temporal/polyfill';
+import { carImportUrl } from './import-url';
 import { isCarCountry } from './countries';
 import { CAR_SOURCES, CHILD_SEAT_CATEGORIES, CarError, type CarDriver, type CarExtras, type CarLocalTime, type CarLocation, type CarSearch, type CarTrackingOptions } from './types';
 import { validateCarProviders } from './preferences';
@@ -109,6 +110,7 @@ export function validateCarSearch(raw: unknown, now = new Date(), options: { all
   const currency = carText(r.currency, 3, 'currency').toUpperCase();
   currencyPrecision(currency);
   const sources = validateCarProviders(r.sources);
+  const sourceUrl = carImportUrl(r.sourceUrl, sources);
   for (const source of sources) {
     for (const place of [pickup, dropoff]) {
       if (!place.providerIds[source] && !(options.allowUnresolvedProviders && place.catalog)) throw new CarError(`Select pickup and return locations for ${source}`);
@@ -129,6 +131,7 @@ export function validateCarSearch(raw: unknown, now = new Date(), options: { all
   }
   return {
     pickup, dropoff, pickupAt, dropoffAt, driver: validateCarDriver(r.driver), currency, sources, extras,
+    ...(sourceUrl ? { sourceUrl } : {}),
     ...(protectionRecheck ? { protectionRecheck } : {}),
     filters: validateCarFilters(r.filters, currency),
   };

--- a/apps/web/src/lib/hotels/booking-extraction.ts
+++ b/apps/web/src/lib/hotels/booking-extraction.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { bookingPropertyId } from './booking';
 import { verifyHotelContext, type HotelPageCapture } from './extraction';
 import type { HotelOffer, HotelRoom, HotelSearch, HotelSelection, HotelStay } from './types';
 import { hotelAmenities } from './property-metadata';
@@ -65,7 +66,7 @@ export function extractBookingOffers(capture: HotelPageCapture, search: HotelSea
   }
   const url = new URL(capture.url);
   for (const key of ['sid', 'label', 'aid', 'chal_t', 'force_referer']) url.searchParams.delete(key);
-  const propertyId = `booking:${url.pathname.replace(/\.en-gb\.html$/, '.html')}`;
+  const propertyId = bookingPropertyId(url.href);
   return combinations.map(combination => {
     const providerRateId = combination.map(room => room.rate.id).join('+');
     const refundable = combination.every(room => room.refundable === true) ? true : combination.some(room => room.refundable === false) ? false : null;

--- a/apps/web/src/lib/hotels/booking.ts
+++ b/apps/web/src/lib/hotels/booking.ts
@@ -1,5 +1,9 @@
 import type { HotelSearch, HotelSelection, HotelStay } from './types';
 
+export function bookingPropertyId(rawUrl: string): string {
+  return `booking:${new URL(rawUrl).pathname.replace(/\.[a-z]{2}(?:-[a-z]{2})?\.html$/, '.html')}`;
+}
+
 export function bookingSearchUrl(search: HotelSearch, stay: HotelStay, selection?: HotelSelection): string {
   const url = new URL(selection?.propertyUrl ?? 'https://www.booking.com/searchresults.html');
   if (url.protocol !== 'https:' || url.username || url.password || url.port || url.hostname !== 'www.booking.com' || (selection && !/^\/hotel\/[a-z]{2}\/[\w.-]+\.html$/.test(url.pathname))) {

--- a/apps/web/src/lib/hotels/domain.test.ts
+++ b/apps/web/src/lib/hotels/domain.test.ts
@@ -43,6 +43,15 @@ describe('hotel search criteria', () => {
     expect(() => validateHotelSearch({ ...input, dateMode: 'window', minNights: 5, maxNights: 7 }, NOW)).toThrow(/No valid/);
   });
 });
+describe('imported hotel selection', () => {
+  it('keeps a selected property in the validated search', () => {
+    const sourceUrl = 'https://www.booking.com/hotel/gb/strandpalace.html';
+    expect(validateHotelSearch({ ...input, sources: ['booking'], sourceUrl }, NOW).sourceUrl).toBe(sourceUrl);
+  });
+  it('rejects an imported property being searched through other providers', () => {
+    expect(() => validateHotelSearch({ ...input, sources: ['booking', 'google_hotels'], sourceUrl: 'https://www.booking.com/hotel/gb/strandpalace.html' }, NOW)).toThrow(/original provider/);
+  });
+});
 describe('qualifying hotel prices', () => {
   it.each([{ taxesIncluded: false }, { occupancyVerified: false }, { currency: 'GBP' }, { totalPrice: NaN }, { totalPrice: 0 }, { rooms: [{ adults: 1, children: [] }] }])('rejects incomparable offer %j', changes => {
     expect(matchesHotelFilters(offer(changes), search())).toBe(false);

--- a/apps/web/src/lib/hotels/domain.ts
+++ b/apps/web/src/lib/hotels/domain.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_HOTEL_FILTERS, HOTEL_AMENITIES, HOTEL_SOURCES, type HotelSearch, type HotelStay, type HotelOffer, type HotelSelection, type HotelTrackingOptions } from './types';
+import { optionalImportUrl } from '../travel/import-url';
 
 export class HotelError extends Error {
   constructor(message: string, public readonly status = 400) { super(message); this.name = 'HotelError'; }
@@ -64,6 +65,10 @@ export function validateHotelSearch(raw: unknown, now = new Date()): HotelSearch
     maxNights: integer(r.maxNights ?? 7, 1, 30, 'Maximum nights'),
     filters: { ...DEFAULT_HOTEL_FILTERS, maxTotal: hotelPrice(f.maxTotal), refundable: boolean(f.refundable), breakfast: boolean(f.breakfast), minStars: integer(f.minStars ?? 0, 0, 5, 'Hotel class'), minRating: rating, excludedSellers: excluded.map(s => text(s, 100, 'seller')), amenities: [...new Set(amenities)] },
   };
+  try {
+    const sourceUrl = optionalImportUrl(r.sourceUrl, 'hotels', search.sources);
+    if (sourceUrl) search.sourceUrl = sourceUrl;
+  } catch (error) { throw new HotelError(error instanceof Error ? error.message : 'Invalid hotel link'); }
   if (search.maxNights < search.minNights) throw new HotelError('Maximum nights must be at least minimum nights');
   expandHotelStays(search, now);
   return search;

--- a/apps/web/src/lib/hotels/imported-hotel.browser.test.ts
+++ b/apps/web/src/lib/hotels/imported-hotel.browser.test.ts
@@ -1,0 +1,40 @@
+import { createServer, type Server } from 'node:http';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { routeProviderTransport } from '@/test/provider-transport';
+import { searchHotelSource } from './providers';
+import { DEFAULT_HOTEL_FILTERS, type HotelSearch } from './types';
+
+const boundary = vi.hoisted(() => ({ origin: '' }));
+vi.mock('playwright', async original => {
+  const actual = await original<typeof import('playwright')>();
+  return { ...actual, chromium: { ...actual.chromium, launch: async (options: Parameters<typeof actual.chromium.launch>[0]) => routeProviderTransport(await actual.chromium.launch(options), boundary.origin) } };
+});
+
+describe.skipIf(process.env.TRAVEL_BROWSER_TESTS !== '1')('imported hotel property browser flow', () => {
+  let server: Server, changed = false;
+  beforeAll(async () => {
+    server = createServer((request, response) => {
+      const url = new URL(request.url!, 'http://fixture');
+      if (url.pathname.endsWith('/selected.html')) {
+        response.writeHead(302, { location: `https://www.booking.com/hotel/gb/${changed ? 'another' : 'selected'}.en-gb.html${url.search}` }); response.end(); return;
+      }
+      response.setHeader('content-type', 'text/html; charset=utf-8');
+      response.end(`<h1>Selected Hotel</h1><input type="hidden" name="checkin" value="2026-10-20"><input type="hidden" name="checkout" value="2026-10-23"><input type="hidden" name="interval" value="3"><input type="hidden" name="room1" value="A,A"><table><thead><tr><th>Price for 3 nights</th></tr></thead><tbody><tr><td><div data-testid="room-name">Double room</div><div>Sleeps: 2 adults</div><div>Current price £450</div><div>Includes taxes and fees</div><div>Free cancellation</div><div>Breakfast included</div><select name="nr_rooms_double_rate"><option value="0">0</option><option value="2">2</option></select></td></tr></tbody></table>`);
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Missing provider fixture');
+    boundary.origin = `http://127.0.0.1:${address.port}`;
+  });
+  beforeEach(() => { changed = false; });
+  afterAll(async () => { if (server) { server.closeAllConnections(); await new Promise<void>(resolve => server.close(() => resolve())); } });
+  const search: HotelSearch = { sourceUrl: 'https://www.booking.com/hotel/gb/selected.html', destination: 'Selected Hotel', checkIn: '2026-10-20', checkOut: '2026-10-23', dateMode: 'fixed', flexibility: 0, minNights: 3, maxNights: 3, rooms: [{ adults: 2, children: [] }], currency: 'GBP', sources: ['booking'], filters: DEFAULT_HOTEL_FILTERS };
+  it('accepts a language redirect and returns verified rates for the selected property', async () => {
+    const offers = await searchHotelSource(search, search, 'booking');
+    expect(offers).toEqual([expect.objectContaining({ propertyId: 'booking:/hotel/gb/selected.html', totalPrice: 450, currency: 'GBP', roomName: 'Double room', taxesIncluded: true, occupancyVerified: true })]);
+  }, 20000);
+  it('rejects a redirect to another hotel without returning its rates', async () => {
+    changed = true;
+    await expect(searchHotelSource(search, search, 'booking')).rejects.toThrow(/changed.*property/);
+  }, 20000);
+});

--- a/apps/web/src/lib/hotels/imported-hotel.live.test.ts
+++ b/apps/web/src/lib/hotels/imported-hotel.live.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { searchHotelSource } from './providers';
+import { DEFAULT_HOTEL_FILTERS, type HotelSearch, type HotelSource } from './types';
+import fixtures from './provider-fixtures.json';
+
+describe.skipIf(process.env.TRAVEL_LIVE_TESTS !== '1')('selected properties on live hotel providers', () => {
+  it.each([['booking', fixtures.booking], ['google_hotels', fixtures.google]] as const)('loads verified rates for the imported %s property', async (source: HotelSource, fixture) => {
+    const search: HotelSearch = { sourceUrl: fixture.url, destination: fixture.propertyName, checkIn: '2026-10-20', checkOut: '2026-10-23', dateMode: 'fixed', flexibility: 0, minNights: 3, maxNights: 3, rooms: [{ adults: 2, children: [] }], currency: 'USD', sources: [source], filters: DEFAULT_HOTEL_FILTERS };
+    const offers = await searchHotelSource(search, search, source);
+    expect(offers.length).toBeGreaterThan(0);
+    expect(offers.every(offer => offer.source === source && offer.taxesIncluded && offer.occupancyVerified && offer.totalPrice > 0)).toBe(true);
+  }, 90000);
+});

--- a/apps/web/src/lib/hotels/providers.test.ts
+++ b/apps/web/src/lib/hotels/providers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { bookingSearchUrl } from './booking';
+import { bookingSearchUrl, bookingPropertyId } from './booking';
 import { googleSearchUrl } from './google';
 import { extractBookingOffers } from './booking-extraction';
 import { extractGoogleOffers } from './google-extraction';
@@ -13,6 +13,10 @@ const stay = { checkIn: search.checkIn, checkOut: search.checkOut };
 const propertyUrl = 'https://www.booking.com/hotel/gb/strandpalace.html';
 const selection: HotelSelection = { propertyId: 'booking:/hotel/gb/strandpalace.html', source: 'booking', hotelName: 'Strand Palace', propertyUrl, roomName: null, rateName: null, seller: 'Booking.com', refundable: null, breakfast: null };
 describe('hotel provider requests', () => {
+  it('recognizes a property after its provider redirects to a localized URL', () => {
+    expect(bookingPropertyId('https://www.booking.com/hotel/gb/strandpalace.en-gb.html')).toBe(bookingPropertyId('https://www.booking.com/hotel/gb/strandpalace.html'));
+    expect(bookingPropertyId('https://www.booking.com/hotel/gb/another.en-gb.html')).not.toBe(bookingPropertyId('https://www.booking.com/hotel/gb/strandpalace.html'));
+  });
   it('preserves stay dates, each child age, room count and total adults', () => {
     const url = new URL(bookingSearchUrl({ ...search, rooms: [{ adults: 2, children: [4] }, { adults: 1, children: [12] }] }, stay));
     expect(url.searchParams.get('checkin')).toBe(stay.checkIn);

--- a/apps/web/src/lib/hotels/providers.ts
+++ b/apps/web/src/lib/hotels/providers.ts
@@ -1,6 +1,6 @@
 import { launchBrowser, createStealthContext } from '../scraper/browser';
 import { COUNTRY_PROFILES } from '../scraper/country-profiles';
-import { bookingSearchUrl } from './booking';
+import { bookingSearchUrl, bookingPropertyId } from './booking';
 import { googleSearchUrl, selectGoogleTotal } from './google';
 import type { HotelPageCapture } from './extraction';
 import { extractBookingOffers } from './booking-extraction';
@@ -11,6 +11,7 @@ import { captureHotelLinks } from './link-capture';
 import { captureHotelLocation } from './location-capture';
 import type { HotelOffer, HotelSearch, HotelSelection, HotelSource, HotelStay } from './types';
 import { closeTravelBrowser, currentTravelExecution, TravelCleanupError } from '../travel/execution';
+import { travelImportUrl } from '../travel/import-url';
 
 export const HOTEL_DISCOVERY_LIMIT = 8;
 
@@ -62,6 +63,15 @@ export async function captureHotelSource(search: HotelSearch, stay: HotelStay, s
 }
 
 export async function searchHotelSource(search: HotelSearch, stay: HotelStay, source: HotelSource, selection?: HotelSelection): Promise<HotelOffer[]> {
+  if (!selection && search.sourceUrl) {
+    const imported = travelImportUrl(search.sourceUrl, 'hotels');
+    if (imported.source !== source) throw new Error('The hotel link belongs to another provider');
+    const property: HotelSelection = { source, propertyId: '', hotelName: search.destination, propertyUrl: imported.url, roomName: null, rateName: null, seller: '', refundable: null, breakfast: null };
+    const capture = await captureHotelSource(search, stay, source, property);
+    const identity = (url: string) => source === 'booking' ? bookingPropertyId(url) : new URL(url).pathname.replace(/\/$/, '');
+    if (identity(capture.url) !== identity(imported.url)) throw new Error('The provider changed the imported property; no substitute hotel was used');
+    return source === 'booking' ? extractBookingOffers(capture, search, stay) : extractGoogleOffers(capture, search, stay);
+  }
   const capture = await captureHotelSource(search, stay, source, selection);
   if (selection) return source === 'booking' ? extractBookingOffers(capture, search, stay, selection) : extractGoogleOffers(capture, search, stay);
   if (source === 'booking' && capture.rates?.length) return extractBookingOffers(capture, search, stay);

--- a/apps/web/src/lib/hotels/types.ts
+++ b/apps/web/src/lib/hotels/types.ts
@@ -13,6 +13,7 @@ export interface HotelFilters {
   amenities: HotelAmenity[];
 }
 export interface HotelSearch {
+  sourceUrl?: string;
   destination: string;
   dateMode: 'fixed' | 'nearby' | 'window';
   checkIn: string;

--- a/apps/web/src/lib/preview-run.ts
+++ b/apps/web/src/lib/preview-run.ts
@@ -1,6 +1,7 @@
 import type { PriceData } from '@/lib/scraper/extract-prices';
 
 export interface PreviewRequestPayload {
+  sourceUrl?: string;
   dateFrom: string;
   dateTo: string;
   maxPrice: number | null;

--- a/apps/web/src/lib/preview-runner.ts
+++ b/apps/web/src/lib/preview-runner.ts
@@ -26,6 +26,8 @@ import { getModelCosts, resolveApiKey } from '@/lib/scraper/ai-registry';
 import { isKnownAirline } from '@/lib/scraper/airline-urls';
 import { extractPrices, type ExtractionFailureReason, type PriceData } from '@/lib/scraper/extract-prices';
 import { navigateAirlineDirect, navigateGoogleFlights } from '@/lib/scraper/navigate';
+import { assertFlightLinkSearch } from './scraper/flight-link';
+import { scrapeImportedFlight } from './scraper/imported-flight';
 import type { Airport } from '@/lib/scraper/parse-query';
 import {
   buildPreviewDatePairs,
@@ -189,6 +191,7 @@ export interface ExtractionContext {
 }
 
 interface ScrapeRouteParams {
+  sourceUrl?: string;
   origin: string;
   destination: string;
   dateFrom: Date;
@@ -292,6 +295,10 @@ export function validatePreviewPayload(
   // singleton RT legs (common LLM output). Unequal multi×multi still throws.
   const datePairs = buildPreviewDatePairs(outboundDates, returnDates, dateFrom, dateTo, isOneWay);
   const totalTasks = combos * datePairs.length;
+  if (payload.sourceUrl) {
+    if (totalTasks !== 1) throw new Error('An imported flight must keep one route and exact dates');
+    assertFlightLinkSearch(payload.sourceUrl, { origin: origins[0]!.code, destination: destinations[0]!.code, dateFrom: datePairs[0]!.outboundDate, dateTo: datePairs[0]!.returnDate, cabinClass: payload.cabinClass, tripType: payload.tripType });
+  }
 
   if (totalTasks > maxCombos) {
     throw new Error(`Too many date/route combinations (${totalTasks}). Cap is ${maxCombos} (combos x dates).`);
@@ -418,6 +425,16 @@ async function scrapeOneWayEstimate(params: ScrapeRouteParams): Promise<OneWayEs
 type RoutePricing = Pick<RouteResultPayload, 'flights' | 'oneWayEstimate' | 'error'>;
 
 async function scrapeRoute(params: ScrapeRouteParams): Promise<PriceData[]> {
+  if (params.sourceUrl) {
+    const startedAt = Date.now();
+    const result = await scrapeImportedFlight({ ...params, sourceUrl: params.sourceUrl }, params, params.context);
+    const { provider, model, costs } = params.context;
+    await prisma.apiUsageLog.create({ data: { provider, model, inputTokens: result.usage.inputTokens, outputTokens: result.usage.outputTokens,
+      costUsd: (result.usage.inputTokens / 1000) * costs.costPer1kInput + (result.usage.outputTokens / 1000) * costs.costPer1kOutput,
+      operation: 'preview-flights', durationMs: Date.now() - startedAt, error: result.failureReason ?? null } });
+    if (result.failureReason || !result.prices.length) throw new Error('No verified price is available for the selected itinerary');
+    return result.prices;
+  }
   const { origin, destination, dateFrom, dateTo, dateFromStr, cabinClass, tripType } = params;
 
   const searchParams = { origin, destination, dateFrom, dateTo, cabinClass, tripType, currency: params.currency };
@@ -567,7 +584,7 @@ async function scrapeRouteWithEstimate(cacheKey: string, params: ScrapeRoutePara
     return { flights: await cached(cacheKey, () => scrapeRoute(params)) };
   } catch (error) {
     currentTravelExecution()?.check();
-    if (!(error instanceof GoogleFlightsLoadingShellError) || params.tripType === 'one_way') throw error;
+    if (params.sourceUrl || !(error instanceof GoogleFlightsLoadingShellError) || params.tripType === 'one_way') throw error;
   }
 
   // A temporary loading failure must not cache an estimate in place of fares.
@@ -654,7 +671,9 @@ export async function runPreview(
     );
 
     try {
-      const pricing = await scrapeRouteWithEstimate(cacheKey, {
+      const importedCacheKey = payload.sourceUrl ? `${cacheKey}:import:${createHash('sha256').update(payload.sourceUrl).digest('hex')}` : cacheKey;
+      const pricing = await scrapeRouteWithEstimate(importedCacheKey, {
+        sourceUrl: payload.sourceUrl,
         origin: combo.origin.code,
         destination: combo.destination.code,
         dateFrom: taskFrom,

--- a/apps/web/src/lib/scraper/extract-prices.ts
+++ b/apps/web/src/lib/scraper/extract-prices.ts
@@ -21,6 +21,7 @@ export interface PriceData {
 }
 
 export interface QueryFilters {
+  selectedItinerary?: import('./flight-link').FlightLinkSegment[][];
   maxPrice: number | null;
   maxStops: number | null;
   maxDurationHours: number | null;
@@ -56,6 +57,9 @@ export function sanitizeScrapedHtml(html: string): string {
 
 function buildSystemPrompt(filters: QueryFilters, maxResults: number, source: NavigationSource = 'google_flights', currency: string | null = null): string {
   const filterRules: string[] = [];
+  if (filters.selectedItinerary) {
+    filterRules.push(`- This is a selected itinerary booking page. Return only the lowest available TOTAL itinerary fare from its booking options. Exclude alternative flights, separate tickets, upgrades, per-leg prices and per-month payments. The complete selected itinerary is ${JSON.stringify(filters.selectedItinerary)}. If no total for this complete itinerary is displayed, return []. Use the outbound departure date as travelDate.`);
+  }
 
   if (filters.maxPrice) {
     filterRules.push(`- ONLY include flights priced at or below ${filters.maxPrice}`);

--- a/apps/web/src/lib/scraper/flight-link.ts
+++ b/apps/web/src/lib/scraper/flight-link.ts
@@ -1,0 +1,96 @@
+import { travelImportUrl } from '../travel/import-url';
+import type { ParsedFlightQuery } from './parse-query';
+
+interface Field { id: number; value: bigint | Uint8Array }
+export interface FlightLinkSegment { origin: string; destination: string; date: string; airline: string; number: string }
+export interface FlightLink { url: string; legs: FlightLinkSegment[][]; cabinClass: ParsedFlightQuery['cabinClass'] }
+
+function fields(bytes: Uint8Array): Field[] {
+  let offset = 0;
+  const integer = (): bigint => {
+    let value = 0n;
+    for (let shift = 0n; shift < 70n; shift += 7n) {
+      const byte = bytes[offset++];
+      if (byte === undefined) break;
+      value |= BigInt(byte & 127) << shift;
+      if (!(byte & 128)) return value;
+    }
+    throw new Error('Invalid Google Flights link data');
+  };
+  const result: Field[] = [];
+  while (offset < bytes.length) {
+    const tag = Number(integer()), wire = tag & 7;
+    if (tag < 8 || result.length >= 100) throw new Error('Invalid Google Flights link fields');
+    if (wire === 0) { result.push({ id: tag >> 3, value: integer() }); continue; }
+    if (wire !== 2) throw new Error('Unsupported Google Flights link encoding');
+    const length = Number(integer());
+    if (!Number.isSafeInteger(length) || length < 0 || offset + length > bytes.length) throw new Error('Truncated Google Flights link');
+    result.push({ id: tag >> 3, value: bytes.slice(offset, offset + length) }); offset += length;
+  }
+  return result;
+}
+function message(field: Field): Field[] {
+  if (!(field.value instanceof Uint8Array)) throw new Error('Invalid itinerary in Google Flights link');
+  return fields(field.value);
+}
+function text(entries: Field[], id: number, pattern: RegExp): string {
+  const values = entries.filter(field => field.id === id);
+  const value = values[0]?.value;
+  if (values.length !== 1 || !(value instanceof Uint8Array)) throw new Error('The link does not contain a complete selected itinerary');
+  const decoded = new TextDecoder('utf-8', { fatal: true }).decode(value);
+  if (!pattern.test(decoded)) throw new Error('Invalid flight details in the selected link');
+  return decoded;
+}
+function date(entries: Field[], id: number): string {
+  const value = text(entries, id, /^\d{4}-\d{2}-\d{2}$/);
+  if (!Number.isFinite(Date.parse(value)) || new Date(value).toISOString().slice(0, 10) !== value) throw new Error('Invalid flight date');
+  return value;
+}
+
+export function readFlightLink(raw: unknown): FlightLink {
+  const { url } = travelImportUrl(raw, 'flights');
+  const encoded = new URL(url).searchParams.get('tfs')!;
+  if (!/^[A-Za-z0-9_-]+={0,2}$/.test(encoded) || encoded.length > 12000) throw new Error('Invalid Google Flights itinerary encoding');
+  let bytes: Uint8Array;
+  try { bytes = Uint8Array.from(atob(encoded.replace(/-/g, '+').replace(/_/g, '/')), char => char.charCodeAt(0)); }
+  catch { throw new Error('Invalid Google Flights itinerary encoding'); }
+  const root = fields(bytes);
+  const legs = root.filter(field => field.id === 3).map(field => {
+    const leg = message(field), departure = date(leg, 2);
+    const segments = leg.filter(field => field.id === 4).map(field => {
+      const segment = message(field);
+      return { origin: text(segment, 1, /^[A-Z]{3}$/), destination: text(segment, 3, /^[A-Z]{3}$/), date: date(segment, 2), airline: text(segment, 5, /^[A-Z0-9]{2}$/), number: text(segment, 6, /^\d{1,4}[A-Z]?$/) };
+    });
+    if (!segments.length || segments.length > 4 || segments[0]!.date !== departure) throw new Error('Select all flights before copying the booking link');
+    for (let index = 1; index < segments.length; index++) {
+      if (segments[index - 1]!.destination !== segments[index]!.origin || segments[index]!.date < segments[index - 1]!.date) throw new Error('The selected flight connections are inconsistent');
+    }
+    return segments;
+  });
+  if (!legs.length || legs.length > 2) throw new Error('Import supports selected one-way and round-trip itineraries');
+  if (legs.length === 2 && (legs[1]![0]!.origin !== legs[0]!.at(-1)!.destination || legs[1]!.at(-1)!.destination !== legs[0]![0]!.origin || legs[1]![0]!.date <= legs[0]![0]!.date)) throw new Error('Import requires a round trip returning to the departure airport');
+  const cabins = ['economy', 'premium_economy', 'business', 'first'] as const;
+  const cabin = root.find(field => field.id === 9)?.value;
+  const cabinClass = typeof cabin === 'bigint' ? cabins[Number(cabin) - 1] : undefined;
+  if (!cabinClass) throw new Error('The selected link does not specify a supported cabin');
+  // Existing flight trackers price one adult. Do not relabel a group fare.
+  const travelers = root.filter(field => field.id === 8);
+  if (travelers.length !== 1 || travelers[0]!.value !== 1n) throw new Error('Flight link import currently supports one adult');
+  return { url, legs, cabinClass };
+}
+
+export function flightLinkQuery(raw: unknown): ParsedFlightQuery {
+  const link = readFlightLink(raw), first = link.legs[0]![0]!, last = link.legs[0]!.at(-1)!;
+  const outbound = first.date, inbound = link.legs[1]?.[0]?.date;
+  const currency = new URL(link.url).searchParams.get('curr');
+  if (currency && !Intl.supportedValuesOf('currency').includes(currency)) throw new Error('Unsupported flight currency');
+  return { sourceUrl: link.url, origin: first.origin, originName: first.origin, destination: last.destination, destinationName: last.destination,
+    origins: [{ code: first.origin, name: first.origin }], destinations: [{ code: last.destination, name: last.destination }],
+    dateFrom: outbound, dateTo: inbound ?? outbound, outboundDates: [outbound], returnDates: inbound ? [inbound] : [], flexibility: 0,
+    maxPrice: null, maxStops: null, maxDurationHours: null, preferredAirlines: [], timePreference: 'any', cabinClass: link.cabinClass, tripType: inbound ? 'round_trip' : 'one_way', currency };
+}
+
+export function assertFlightLinkSearch(raw: unknown, search: { origin: string; destination: string; dateFrom: string; dateTo: string; cabinClass: string; tripType: string; flexibility?: number }): void {
+  const expected = flightLinkQuery(raw);
+  if (['origin', 'destination', 'dateFrom', 'dateTo', 'cabinClass', 'tripType'].some(key => expected[key as keyof typeof expected] !== search[key as keyof typeof search]) || (search.flexibility ?? 0) !== 0) throw new Error('The flight link must keep its original route, dates and cabin. Remove the link to change the search.');
+}

--- a/apps/web/src/lib/scraper/imported-flight.browser.test.ts
+++ b/apps/web/src/lib/scraper/imported-flight.browser.test.ts
@@ -1,0 +1,63 @@
+import { createServer, type Server } from 'node:http';
+import { beforeAll, beforeEach, afterAll, describe, expect, it, vi } from 'vitest';
+import { routeProviderTransport } from '@/test/provider-transport';
+import { FLIGHT_IMPORT_URL, FLIGHT_IMPORT_TEXT } from '@/test/import-fixtures';
+import { flightLinkQuery } from './flight-link';
+import { captureImportedFlight, scrapeImportedFlight } from './imported-flight';
+
+const boundary = vi.hoisted(() => ({ origin: '', extract: vi.fn() }));
+vi.mock('playwright', async original => {
+  const actual = await original<typeof import('playwright')>();
+  return { ...actual, chromium: { ...actual.chromium, launch: async (options: Parameters<typeof actual.chromium.launch>[0]) => routeProviderTransport(await actual.chromium.launch(options), boundary.origin) } };
+});
+vi.mock('./ai-registry', async original => {
+  const actual = await original<typeof import('./ai-registry')>();
+  return { ...actual, EXTRACTION_PROVIDERS: { ...actual.EXTRACTION_PROVIDERS, openai: { ...actual.EXTRACTION_PROVIDERS.openai, extract: boundary.extract } } };
+});
+vi.mock('@/lib/prisma', () => ({ prisma: { extractionConfig: { findFirst: vi.fn().mockResolvedValue(null), findUnique: vi.fn().mockResolvedValue(null) } } }));
+
+describe.skipIf(process.env.TRAVEL_BROWSER_TESTS !== '1')('imported flight browser and price extraction', () => {
+  let server: Server, changed = false, redirect = false;
+  beforeAll(async () => {
+    server = createServer((request, response) => {
+      if (redirect) { response.writeHead(302, { location: 'https://127.0.0.1/private' }); response.end(); return; }
+      const text = changed ? FLIGHT_IMPORT_TEXT.replace('SK 943', 'SK 945') : FLIGHT_IMPORT_TEXT;
+      response.setHeader('content-type', 'text/html; charset=utf-8');
+      response.end(`<button aria-label="Currency EUR">EUR</button><button aria-label="Flight details. Departing flight" aria-expanded="false" onclick="this.setAttribute('aria-expanded','true');document.getElementById('details').hidden=false">Details</button><button aria-label="Flight details. Return flight" aria-expanded="false" onclick="this.setAttribute('aria-expanded','true')">Details</button><p>Book with a provider</p><pre id="details" hidden>${text.replace(/&/g, '&amp;').replace(/</g, '&lt;')}</pre>`);
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Missing provider fixture');
+    boundary.origin = `http://127.0.0.1:${address.port}`;
+  });
+  beforeEach(() => {
+    changed = false; redirect = false;
+    boundary.extract.mockReset().mockResolvedValue({ content: JSON.stringify([{ travelDate: '2026-10-04', price: 711, currency: 'EUR', airline: 'Scandinavian Airlines', stops: 1 }]), usage: { inputTokens: 100, outputTokens: 30 } });
+  });
+  afterAll(async () => { if (server) { server.closeAllConnections(); await new Promise<void>(resolve => server.close(() => resolve())); } });
+  const query = flightLinkQuery(FLIGHT_IMPORT_URL);
+  const params = { ...query, sourceUrl: FLIGHT_IMPORT_URL, dateFrom: new Date(query.dateFrom), dateTo: new Date(query.dateTo) };
+  const config = { provider: 'openai', model: 'test-model', customBaseUrl: null, apiKey: 'test-key' };
+
+  it('expands the selected legs and records a displayed total with stable flight identity', async () => {
+    const result = await scrapeImportedFlight(params, query, config);
+    expect(result).toMatchObject({ prices: [{ price: 711, currency: 'EUR', bookingUrl: FLIGHT_IMPORT_URL, flightNumber: 'SK 944' }], usage: { inputTokens: 100, outputTokens: 30 } });
+    expect(result.failureReason).toBeUndefined();
+  }, 15000);
+  it('rejects invented amounts even when the extraction provider returns valid JSON', async () => {
+    boundary.extract.mockResolvedValue({ content: JSON.stringify([{ travelDate: '2026-10-04', price: 12, currency: 'EUR', airline: 'Scandinavian Airlines', stops: 1 }]), usage: { inputTokens: 100, outputTokens: 30 } });
+    const result = await scrapeImportedFlight(params, query, config);
+    expect(result.prices).toEqual([]);
+    expect(result.failureReason).toBeTruthy();
+    expect(result.usage).toEqual({ inputTokens: 100, outputTokens: 30 });
+  }, 15000);
+  it('rejects a changed return flight before asking the extraction provider for a price', async () => {
+    changed = true;
+    await expect(scrapeImportedFlight(params, query, config)).rejects.toThrow(/SK 943/);
+    expect(boundary.extract).not.toHaveBeenCalled();
+  }, 15000);
+  it('blocks a provider redirect into a private network', async () => {
+    redirect = true;
+    await expect(captureImportedFlight(params)).rejects.toThrow();
+  }, 15000);
+});

--- a/apps/web/src/lib/scraper/imported-flight.live.test.ts
+++ b/apps/web/src/lib/scraper/imported-flight.live.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { captureImportedFlight } from './imported-flight';
+import { flightLinkQuery } from './flight-link';
+import { FLIGHT_IMPORT_URL } from '@/test/import-fixtures';
+
+describe.skipIf(process.env.TRAVEL_LIVE_TESTS !== '1')('selected itinerary on live Google Flights', () => {
+  it('opens every selected segment and verifies the booking currency', async () => {
+    const original = new URL(FLIGHT_IMPORT_URL);
+    original.searchParams.delete('curr');
+    original.searchParams.set('tfu', 'CnRDalJJUTAxM1gwWlZUVXc0UTNkQlNWSkVPR2RDUnkwdExTMHRMUzB0TFc5NWRtb3hNVUZCUVVGQlIzRnJkM1IzUkdNMGRVRkJFZ3hUU3pFMk16QjhVMHM1TkRNYUN3aVN0Z1FRQWhvRFJWVlNPQnh3L1pBRhICCAAiAA');
+    original.searchParams.set('gl', 'DE');
+    original.searchParams.set('client', 'safari');
+    const query = flightLinkQuery(original.href);
+    const result = await captureImportedFlight({ ...query, sourceUrl: original.href, dateFrom: new Date(query.dateFrom), dateTo: new Date(query.dateTo) });
+    expect(result.currency).toBe('EUR');
+    expect(result.link.legs.flat().map(segment => `${segment.airline} ${segment.number}`)).toEqual(['SK 944', 'SK 629', 'SK 1630', 'SK 943']);
+    expect(result.html).toMatch(/Booking options/);
+  }, 90000);
+});

--- a/apps/web/src/lib/scraper/imported-flight.test.ts
+++ b/apps/web/src/lib/scraper/imported-flight.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { readFlightLink } from './flight-link';
+import { verifyImportedFlightPage } from './imported-flight';
+import { FLIGHT_IMPORT_URL, FLIGHT_IMPORT_TEXT } from '@/test/import-fixtures';
+
+describe('selected flight page verification', () => {
+  it('accepts the complete displayed itinerary, including an overnight connection', () => {
+    expect(() => verifyImportedFlightPage(readFlightLink(FLIGHT_IMPORT_URL), FLIGHT_IMPORT_URL, FLIGHT_IMPORT_TEXT)).not.toThrow();
+  });
+  it.each([
+    FLIGHT_IMPORT_TEXT.replace('SK 943', 'SK 945'),
+    FLIGHT_IMPORT_TEXT.replace('Economy', 'Business'),
+    FLIGHT_IMPORT_TEXT.replace('Mon, Oct 19', 'Tue, Oct 20'),
+    FLIGHT_IMPORT_TEXT.replaceAll('+1', ''),
+    FLIGHT_IMPORT_TEXT.replace('8:50 PM+1Copenhagen', '8:50 PM+2Copenhagen'),
+    FLIGHT_IMPORT_TEXT.replace('10:10 AMDuesseldorf', '10:10 AM+1Duesseldorf'),
+    FLIGHT_IMPORT_TEXT.replace('4:10 PMChicago O\'Hare International Airport (ORD)', '4:10 PMNew York (JFK)'),
+    'No booking options',
+  ])('rejects incomplete or changed itineraries before extracting a price', text => {
+    expect(() => verifyImportedFlightPage(readFlightLink(FLIGHT_IMPORT_URL), FLIGHT_IMPORT_URL, text)).toThrow();
+  });
+  it('rejects a redirect to an unselected results page', () => {
+    expect(() => verifyImportedFlightPage(readFlightLink(FLIGHT_IMPORT_URL), 'https://www.google.com/travel/flights', FLIGHT_IMPORT_TEXT)).toThrow();
+  });
+});

--- a/apps/web/src/lib/scraper/imported-flight.ts
+++ b/apps/web/src/lib/scraper/imported-flight.ts
@@ -1,0 +1,78 @@
+import { launchBrowser, createStealthContext } from './browser';
+import { closeTravelBrowser } from '../travel/execution';
+import { guardTravelNavigation } from '../travel/navigation';
+import { readFlightLink, assertFlightLinkSearch, type FlightLink } from './flight-link';
+import { extractPrices, type QueryFilters, type ExtractionConfigOverride } from './extract-prices';
+import type { FlightSearchParams } from './navigate';
+import type { CountryProfile } from './country-profiles';
+
+export function verifyImportedFlightPage(link: FlightLink, finalUrl: string, text: string): void {
+  const actual = readFlightLink(finalUrl);
+  if (JSON.stringify(actual.legs) !== JSON.stringify(link.legs) || actual.cabinClass !== link.cabinClass) throw new Error('Google changed the selected itinerary; no substitute flight was used');
+  if (/unusual traffic|captcha|access denied|no booking options|flight.*unavailable/i.test(text)) throw new Error('The selected itinerary could not be priced');
+  for (const [index, leg] of link.legs.entries()) {
+    const section = index === 0 ? text.split('Departing flight')[1]?.split('Returning flight')[0] : text.split('Returning flight')[1];
+    if (!section) throw new Error('Google did not display the selected flight details');
+    const departure = leg[0]!.date, date = new Date(`${departure}T12:00:00Z`), month = date.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' });
+    if (!section.includes(departure) && !new RegExp(`\\b${month}\\s+${date.getUTCDate()}\\b|\\b${date.getUTCDate()}\\s+${month}\\b`, 'i').test(section)) throw new Error('Google did not display the selected flight dates');
+    let offset = 0;
+    for (const segment of leg) {
+      const number = new RegExp(`${segment.airline}\\s*${segment.number}\\b`).exec(section.slice(offset));
+      if (!number) throw new Error(`Google did not display selected flight ${segment.airline} ${segment.number}`);
+      const details = section.slice(offset, offset + number.index);
+      if (!details.includes(`(${segment.origin})`) || !details.includes(`(${segment.destination})`)) throw new Error('Google did not verify the selected flight airports');
+      const cabin = { economy: 'Economy', premium_economy: 'Premium economy', business: 'Business', first: 'First' }[link.cabinClass];
+      if (!details.split('\n').some(line => line.trim().toLowerCase() === cabin.toLowerCase())) throw new Error('Google did not verify the selected cabin on every segment');
+      const dayOffset = Math.round((Date.parse(segment.date) - Date.parse(departure)) / 86400000);
+      const displayedDeparture = new RegExp(`^\\d{1,2}:\\d{2}\\s*[AP]M(?:\\+(\\d+))?[^\\n]*\\(${segment.origin}\\)`, 'm').exec(details);
+      if (!displayedDeparture || Number(displayedDeparture[1] ?? 0) !== dayOffset) throw new Error('Google did not verify the connection departure date');
+      offset += number.index + number[0].length;
+    }
+  }
+  if (!/booking options|book with/i.test(text)) throw new Error('Google did not display booking options for the selected itinerary');
+}
+
+export async function captureImportedFlight(params: FlightSearchParams & { sourceUrl: string }, countryProfile?: CountryProfile, proxyUrl?: string) {
+  assertFlightLinkSearch(params.sourceUrl, { ...params, dateFrom: params.dateFrom.toISOString().slice(0, 10), dateTo: params.dateTo.toISOString().slice(0, 10), cabinClass: params.cabinClass ?? 'economy', tripType: params.tripType ?? 'round_trip' });
+  const link = readFlightLink(params.sourceUrl), url = new URL(link.url);
+  url.searchParams.set('hl', 'en');
+  if (params.currency) url.searchParams.set('curr', params.currency);
+  if (params.country) url.searchParams.set('gl', params.country);
+  const browser = await launchBrowser({ proxyUrl });
+  let failure: unknown;
+  try {
+    const context = await createStealthContext(browser, { countryProfile, proxyUrl }), page = await context.newPage();
+    const guard = await guardTravelNavigation(page, 'imported-flight', destination => destination.protocol === 'https:' && !destination.port && !destination.username && !destination.password && ['www.google.com', 'consent.google.com'].includes(destination.hostname));
+    await page.goto(url.href, { waitUntil: 'domcontentloaded', timeout: 45000 });
+    await guard.settle();
+    const consent = page.getByRole('button', { name: /^(Reject all|Accept all)$/ }).first();
+    if (await consent.isVisible()) { await consent.click(); await page.waitForTimeout(2000); await guard.settle(); }
+    await page.getByText(/Booking options|Book with/).first().waitFor({ timeout: 30000 });
+    const details = page.getByRole('button', { name: /^Flight details\./ });
+    if (await details.count() !== link.legs.length) throw new Error('Google did not return the selected itinerary');
+    for (const detail of await details.all()) if (await detail.getAttribute('aria-expanded') !== 'true') await detail.click();
+    const html = await page.locator('body').innerText();
+    verifyImportedFlightPage(link, page.url(), html);
+    const currencyLabel = await page.getByRole('button', { name: /^Currency [A-Z]{3}$/ }).getAttribute('aria-label');
+    const currency = currencyLabel?.slice(-3);
+    if (!currency || (params.currency && currency !== params.currency)) throw new Error('Google did not verify the requested fare currency');
+    return { html, url: url.href, link, currency };
+  } catch (error) { failure = error; throw error; }
+  finally { await closeTravelBrowser(browser, failure); }
+}
+
+export async function scrapeImportedFlight(params: FlightSearchParams & { sourceUrl: string }, filters: QueryFilters, config?: ExtractionConfigOverride, countryProfile?: CountryProfile, proxyUrl?: string) {
+  const { html, url, link, currency } = await captureImportedFlight(params, countryProfile, proxyUrl);
+  const result = await extractPrices(html, url, link.legs[0]![0]!.date, { ...filters, selectedItinerary: link.legs }, 1, true, 'google_flights', currency, config);
+  const first = link.legs[0]![0]!;
+  const bookingLines = html.split('Booking options')[1]?.split('Price insights')[0]?.split('\n').map(line => line.trim()) ?? [];
+  const prices = result.prices.filter(price => {
+    if (price.travelDate !== first.date || price.currency !== currency) return false;
+    return (['symbol', 'narrowSymbol', 'code'] as const).some(currencyDisplay => {
+      const displayed = new Intl.NumberFormat('en-US', { style: 'currency', currency, currencyDisplay, minimumFractionDigits: 0, maximumFractionDigits: 2 }).format(price.price).replace(/\s/g, '');
+      return bookingLines.some(line => line.replace(/\s/g, '') === displayed);
+    });
+  });
+  return { ...result, failureReason: prices.length ? result.failureReason : result.failureReason ?? 'empty_extraction' as const,
+    prices: prices.map(price => ({ ...price, bookingUrl: link.url, flightNumber: `${first.airline} ${first.number}` })) };
+}

--- a/apps/web/src/lib/scraper/navigate.ts
+++ b/apps/web/src/lib/scraper/navigate.ts
@@ -35,6 +35,7 @@ async function simulateHumanBehavior(page: Page): Promise<void> {
 }
 
 export interface FlightSearchParams {
+  sourceUrl?: string | null;
   origin: string;
   destination: string;
   dateFrom: Date;

--- a/apps/web/src/lib/scraper/parse-query.ts
+++ b/apps/web/src/lib/scraper/parse-query.ts
@@ -9,6 +9,7 @@ export interface Airport {
 }
 
 export interface ParsedFlightQuery {
+  sourceUrl?: string;
   origin: string;      // primary origin IATA code (first in origins array)
   originName: string;  // primary origin city name
   destination: string; // primary destination IATA code (first in destinations array)

--- a/apps/web/src/lib/scraper/run-scrape.ts
+++ b/apps/web/src/lib/scraper/run-scrape.ts
@@ -11,6 +11,8 @@ import {
 import { extractPrices, type ExtractionFailureReason } from './extract-prices';
 import { getModelCosts } from './ai-registry';
 import { isKnownAirline } from './airline-urls';
+import { scrapeImportedFlight } from './imported-flight';
+import { assertFlightLinkSearch } from './flight-link';
 import { getCountryProfile } from './country-profiles';
 import { expandQueryDates } from './scrape-dates';
 import { currentTravelContext, checkTravelAuthority, travelTransaction } from '../travel/context';
@@ -146,6 +148,10 @@ async function scrapeOneDatePair(
   proxyUrl: string | undefined,
   vpnCountry: string | null,
 ): Promise<PairScrapeResult> {
+  if (pairParams.sourceUrl) {
+    const result = await scrapeImportedFlight({ ...pairParams, sourceUrl: pairParams.sourceUrl }, filters, undefined, countryProfile, proxyUrl);
+    return { prices: result.prices, inputTokens: result.usage.inputTokens, outputTokens: result.usage.outputTokens, sources: new Set(['google_flights']), lastFailureReason: result.failureReason };
+  }
   const effectiveCurrency = pairParams.currency ?? null;
   const travelDateFallback = pairParams.dateFrom.toISOString().split('T')[0]!;
 
@@ -278,6 +284,7 @@ async function scrapeQueryForCountry(
   fetchRunId: string,
 ): Promise<ScrapeResult> {
   const countryProfile = vpnCountry ? getCountryProfile(vpnCountry) : undefined;
+  if (searchParams.sourceUrl) assertFlightLinkSearch(searchParams.sourceUrl, { ...searchParams, dateFrom: searchParams.dateFrom.toISOString().slice(0, 10), dateTo: searchParams.dateTo.toISOString().slice(0, 10), cabinClass: searchParams.cabinClass ?? 'economy', tripType: searchParams.tripType ?? 'round_trip', flexibility: query.flexibility });
 
   const directAirlines = query.preferredAirlines.filter(isKnownAirline);
   const useAirlineDirect = directAirlines.length > 0;

--- a/apps/web/src/lib/travel/import-draft.test.ts
+++ b/apps/web/src/lib/travel/import-draft.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { importTravelDraft } from './import-draft';
+import { travelImportUrl } from './import-url';
+import { readFlightLink, assertFlightLinkSearch, flightLinkQuery } from '../scraper/flight-link';
+import { FLIGHT_IMPORT_URL, CAR_IMPORT_URL } from '@/test/import-fixtures';
+import fixtures from '../hotels/provider-fixtures.json';
+
+describe('selected travel link import', () => {
+  it('recovers both flights and overnight connections without losing the selected return', () => {
+    const draft = importTravelDraft(FLIGHT_IMPORT_URL, 'flights');
+    expect(draft.flight).toMatchObject({ origin: 'ORD', destination: 'DUS', dateFrom: '2026-10-04', dateTo: '2026-10-19', tripType: 'round_trip', cabinClass: 'economy', flexibility: 0, currency: 'EUR' });
+    expect(readFlightLink(FLIGHT_IMPORT_URL).legs).toEqual([
+      [{ origin: 'ORD', destination: 'CPH', date: '2026-10-04', airline: 'SK', number: '944' }, { origin: 'CPH', destination: 'DUS', date: '2026-10-05', airline: 'SK', number: '629' }],
+      [{ origin: 'DUS', destination: 'CPH', date: '2026-10-19', airline: 'SK', number: '1630' }, { origin: 'CPH', destination: 'ORD', date: '2026-10-19', airline: 'SK', number: '943' }],
+    ]);
+  });
+  it.each([{ dateTo: '2026-10-20' }, { flexibility: 1 }, { cabinClass: 'business' }, { origin: 'MDW' }, { tripType: 'one_way' }])('rejects changing imported flight scope: %j', change => {
+    expect(() => assertFlightLinkSearch(FLIGHT_IMPORT_URL, { ...flightLinkQuery(FLIGHT_IMPORT_URL), ...change })).toThrow(/original/);
+  });
+  it.each(['%', 'AAAA', 'CBwQAhpl', 'A'.repeat(12001)])('rejects malformed or oversized encoded itineraries', tfs => {
+    expect(() => readFlightLink(`https://www.google.com/travel/flights/booking?tfs=${tfs}`)).toThrow();
+  });
+  it.each(['http://www.booking.com/hotel/gb/a.html', 'https://www.booking.com.evil.test/hotel/gb/a.html', 'https://www.booking.com@127.0.0.1/hotel/gb/a.html', 'https://www.booking.com:444/hotel/gb/a.html', 'https://www.booking.com/searchresults.html', 'https://www.booking.com/confirmation', 'file:///tmp/test'])('rejects non-public or unsupported hotel link %s', url => {
+    expect(() => travelImportUrl(url, 'hotels')).toThrow();
+  });
+  it('imports property dates and exact single-room child ages', () => {
+    const draft = importTravelDraft('https://booking.com/hotel/gb/strandpalace.html?checkin=2026-10-20&checkout=2026-10-23&group_adults=2&no_rooms=1&group_children=1&age=7&selected_currency=GBP', 'hotels');
+    expect(draft.hotel).toMatchObject({ sources: ['booking'], checkIn: '2026-10-20', checkOut: '2026-10-23', currency: 'GBP', rooms: [{ adults: 2, children: [7] }] });
+    expect(draft.url).toContain('https://www.booking.com/hotel/gb/strandpalace.html');
+  });
+  it('preserves the Google property identity and selected dates', () => {
+    const draft = importTravelDraft(fixtures.google.url, 'hotels');
+    expect(new URL(draft.url).pathname).toBe(new URL(fixtures.google.url).pathname);
+    expect(draft.hotel).toMatchObject({ sources: ['google_hotels'], checkIn: '2026-10-20', checkOut: '2026-10-23' });
+  });
+  it('leaves missing rental licence tenure and catalog locations for the user to supply', () => {
+    const draft = importTravelDraft(CAR_IMPORT_URL, 'cars');
+    expect(draft.car).toMatchObject({ pickupAt: { date: '2026-10-15', time: '12:00' }, dropoffAt: { date: '2026-10-18', time: '12:00' }, driver: { age: 35, licenceYears: null, residenceCountry: 'GB' }, pickupQuery: null, dropoffQuery: null, sources: ['autoeurope'], currency: 'USD' });
+  });
+  it('decodes DiscoverCars dates without treating provider IDs as catalog locations', () => {
+    const sq = Buffer.from(JSON.stringify({ PickupLocationId: 1712, DropOffLocationId: 1712, PickupDateTime: '2026-10-15T12:00:00', DropOffDateTime: '2026-10-18T12:00:00', DriverAge: 35, ResidenceCountry: 'GB' })).toString('base64');
+    const draft = importTravelDraft(`https://www.discovercars.com/offer/12345678-abcd-abcd-abcd-123456789abc-ab12?sq=${encodeURIComponent(sq)}`, 'cars');
+    expect(draft.car).toMatchObject({ pickupAt: { date: '2026-10-15', time: '12:00' }, pickupQuery: null, driver: { age: 35, licenceYears: null, residenceCountry: 'GB' }, sources: ['discovercars'] });
+  });
+});

--- a/apps/web/src/lib/travel/import-draft.ts
+++ b/apps/web/src/lib/travel/import-draft.ts
@@ -1,0 +1,54 @@
+import { travelImportUrl, type ImportKind } from './import-url';
+import { flightLinkQuery } from '../scraper/flight-link';
+import { googleSelectedDates } from '../hotels/google';
+import type { HotelSearch, HotelSource } from '../hotels/types';
+import { validateCarParseDraft, type CarParseDraft } from '../cars/parse-draft';
+import type { CarSource } from '../cars/types';
+
+export function importTravelDraft(raw: unknown, kind: ImportKind) {
+  const imported = travelImportUrl(raw, kind), url = new URL(imported.url), query = url.searchParams;
+  if (kind === 'flights') return { kind, url: imported.url, flight: flightLinkQuery(imported.url) };
+  if (kind === 'hotels') {
+    const dates = imported.source === 'google_hotels' ? googleSelectedDates(imported.url) : [query.get('checkin'), query.get('checkout')];
+    const hotel: Partial<HotelSearch> = { sourceUrl: imported.url, sources: [imported.source as HotelSource], dateMode: 'fixed', flexibility: 0 };
+    if (dates[0]) hotel.checkIn = dates[0];
+    if (dates[1]) hotel.checkOut = dates[1];
+    if (imported.source === 'booking') hotel.destination = url.pathname.split('/').at(-1)!.replace(/(?:\.[a-z-]+)?\.html$/, '').replace(/-/g, ' ');
+    const currency = query.get('selected_currency') ?? query.get('curr');
+    if (currency && Intl.supportedValuesOf('currency').includes(currency)) hotel.currency = currency;
+    // Multi-room allocation and children must be explicitly reviewed in the form.
+    const adults = Number(query.get('group_adults')), rooms = Number(query.get('no_rooms'));
+    const children = Number(query.get('group_children') ?? 0), ages = query.getAll('age').map(Number);
+    if (rooms === 1 && adults >= 1 && adults <= 6 && children === ages.length && ages.every(age => Number.isInteger(age) && age >= 0 && age <= 17)) hotel.rooms = [{ adults, children: ages }];
+    return { kind, url: imported.url, hotel };
+  }
+  let data: Record<string, unknown> = {};
+  if (imported.source === 'discovercars') {
+    try {
+      const value: unknown = JSON.parse(Buffer.from(query.get('sq')!, 'base64').toString('utf8'));
+      if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error();
+      data = value as Record<string, unknown>;
+    } catch { throw new Error('The rental link contains invalid search details'); }
+  }
+  const datetime = (value: unknown) => {
+    const match = typeof value === 'string' ? value.match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2})(?::00)?$/) : null;
+    return { date: match?.[1] ?? null, time: match?.[2] ?? null };
+  };
+  const source = imported.source as CarSource;
+  const driverAge = source === 'discovercars' ? data.DriverAge : query.get('drivers_age');
+  const residence = source === 'discovercars' ? data.ResidenceCountry : query.get('residence_country');
+  const pickupId = source === 'discovercars' ? data.PickupLocationId : query.get('pickup_location');
+  const dropoffId = source === 'discovercars' ? data.DropOffLocationId : query.get('dropoff_location');
+  const car: CarParseDraft = validateCarParseDraft({
+    sameLocation: pickupId != null && dropoffId != null ? pickupId === dropoffId : null,
+    pickupQuery: source === 'discovercars' && typeof data.PickupLocationName === 'string' ? data.PickupLocationName : null,
+    dropoffQuery: source === 'discovercars' && typeof data.DropOffLocationName === 'string' ? data.DropOffLocationName : null,
+    pickupAt: datetime(source === 'discovercars' ? data.PickupDateTime : `${query.get('pickup_date')}T${query.get('pickup_time')}`),
+    dropoffAt: datetime(source === 'discovercars' ? data.DropOffDateTime : `${query.get('dropoff_date')}T${query.get('dropoff_time')}`),
+    driver: { age: driverAge === undefined || driverAge === null ? null : Number(driverAge), residenceCountry: typeof residence === 'string' ? residence.toUpperCase() : null },
+    currency: query.get('currency'), sources: [source], warnings: [],
+  });
+  return { kind, url: imported.url, car };
+}
+
+export type TravelImportDraft = ReturnType<typeof importTravelDraft>;

--- a/apps/web/src/lib/travel/import-url.ts
+++ b/apps/web/src/lib/travel/import-url.ts
@@ -1,0 +1,33 @@
+export type ImportKind = 'flights' | 'hotels' | 'cars';
+export type ImportSource = 'google_flights' | 'google_hotels' | 'booking' | 'discovercars' | 'autoeurope';
+
+/** Only selected, public product pages are eligible for import. */
+export function travelImportUrl(raw: unknown, kind: ImportKind): { url: string; source: ImportSource } {
+  if (typeof raw !== 'string' || raw.length > 16000 || !raw.trim()) throw new Error('Paste a selected booking link');
+  let url: URL;
+  try { url = new URL(raw.trim()); } catch { throw new Error('Paste a complete HTTPS booking link'); }
+  if (url.protocol !== 'https:' || url.username || url.password || url.port) throw new Error('Use a public HTTPS booking link without credentials');
+  let source: ImportSource | undefined;
+  if (kind === 'flights' && url.hostname === 'www.google.com' && url.pathname === '/travel/flights/booking' && url.searchParams.has('tfs')) source = 'google_flights';
+  if (kind === 'hotels') {
+    if (url.hostname === 'www.google.com' && /^\/travel\/hotels\/entity\/[A-Za-z0-9_-]+\/?$/.test(url.pathname)) source = 'google_hotels';
+    if (['booking.com', 'www.booking.com'].includes(url.hostname) && /^\/hotel\/[a-z]{2}\/[\w.-]+\.html$/.test(url.pathname)) { source = 'booking'; url.hostname = 'www.booking.com'; }
+  }
+  if (kind === 'cars') {
+    if (url.hostname === 'www.discovercars.com' && /^\/offer\/[0-9a-f-]{36}-[A-Za-z0-9]+$/i.test(url.pathname) && url.searchParams.has('sq')) source = 'discovercars';
+    if (url.hostname === 'book.autoeurope.com' && url.pathname === '/en-us/options' && url.searchParams.get('rate_reference')) source = 'autoeurope';
+  }
+  if (!source) throw new Error(`This ${kind} link is not supported. Copy the selected product link from a supported provider, rather than a search, short link or reservation confirmation.`);
+  for (const key of new Set(url.searchParams.keys())) if (key !== 'age' && url.searchParams.getAll(key).length > 1) throw new Error('The link contains conflicting repeated search parameters');
+  url.hash = '';
+  for (const key of [...url.searchParams.keys()]) if (/^(utm_|client$|ved$)/.test(key)) url.searchParams.delete(key);
+  if (source === 'booking') url.searchParams.delete('sid');
+  return { url: url.href, source };
+}
+
+export function optionalImportUrl(raw: unknown, kind: ImportKind, sources: readonly string[]): string | undefined {
+  if (raw === undefined || raw === null || raw === '') return undefined;
+  const imported = travelImportUrl(raw, kind);
+  if (sources.length !== 1 || sources[0] !== imported.source) throw new Error('An imported selection must use only its original provider');
+  return imported.url;
+}

--- a/apps/web/src/test/import-fixtures.ts
+++ b/apps/web/src/test/import-fixtures.ts
@@ -1,0 +1,43 @@
+/** Selected itinerary supplied as a real Google Flights booking link. */
+export const FLIGHT_IMPORT_URL = 'https://www.google.com/travel/flights/booking?tfs=CBwQAhplEgoyMDI2LTEwLTA0Ih8KA09SRBIKMjAyNi0xMC0wNBoDQ1BIKgJTSzIDOTQ0Ih8KA0NQSBIKMjAyNi0xMC0wNRoDRFVTKgJTSzIDNjI5agcIARIDT1JEcgwIAhIIL20vMGhmN2waZhIKMjAyNi0xMC0xOSIgCgNEVVMSCjIwMjYtMTAtMTkaA0NQSCoCU0syBDE2MzAiHwoDQ1BIEgoyMDI2LTEwLTE5GgNPUkQqAlNLMgM5NDNqDAgCEggvbS8waGY3bHIHCAESA09SREABSAFwAYIBCwj___________8BmAEB&hl=en&curr=EUR';
+
+export const FLIGHT_IMPORT_TEXT = `Selected flights
+Departing flight
+Sun, Oct 4
+7:15 PMChicago O'Hare International Airport (ORD)
+Travel time: 8 hr 30 minOvernight
+10:45 AM+1Copenhagen Airport (CPH)
+Scandinavian Airlines
+Economy
+Airbus A330SK 944
+10 hr 5 min layoverCopenhagen (CPH)Long layover
+8:50 PM+1Copenhagen Airport (CPH)
+Travel time: 1 hr 20 min
+10:10 PM+1Duesseldorf Airport (DUS)
+Scandinavian Airlines
+Economy
+Canadair RJ 900SK 629
+Returning flight
+Mon, Oct 19
+10:10 AMDuesseldorf Airport (DUS)
+Travel time: 1 hr 15 min
+11:25 AMCopenhagen Airport (CPH)
+Scandinavian Airlines
+Economy
+Embraer 195SK 1630
+2 hr 30 min layoverCopenhagen (CPH)
+1:55 PMCopenhagen Airport (CPH)
+Travel time: 9 hr 15 min
+4:10 PMChicago O'Hare International Airport (ORD)
+Scandinavian Airlines
+Economy
+Airbus A330SK 943
+Booking options
+Book with Example Seller
+€711
+$825
+Continue
+Price insights
+€711 is typical`;
+
+export const CAR_IMPORT_URL = 'https://book.autoeurope.com/en-us/options?rate_reference=selected&pickup_location=547&dropoff_location=547&pickup_date=2026-10-15&dropoff_date=2026-10-18&pickup_time=12%3A00&dropoff_time=12%3A00&drivers_age=35&residence_country=GB&currency=USD';

--- a/apps/web/src/test/provider-transport.ts
+++ b/apps/web/src/test/provider-transport.ts
@@ -1,0 +1,24 @@
+import type { Browser, Route } from 'playwright';
+
+/** Keep browser, redirects and DOM processing real; replace only provider HTTP transport. */
+export function routeProviderTransport(browser: Browser, origin: string): Browser {
+  const newContext = browser.newContext.bind(browser);
+  browser.newContext = async options => {
+    const context = await newContext(options), newPage = context.newPage.bind(context);
+    context.newPage = async () => {
+      const page = await newPage(), register = page.route.bind(page);
+      const fetch = (url: string, options?: Parameters<Route['fetch']>[0]) => {
+        const target = new URL(url);
+        return context.request.get(`${origin}/${target.hostname}${target.pathname}${target.search}`, { ...options, maxRedirects: 0 });
+      };
+      await register('**/*', async route => { await route.fulfill({ response: await fetch(route.request().url()) }); });
+      page.route = async (pattern, handler, options) => register(pattern, async (route, request) => {
+        route.fetch = options => fetch(request.url(), options);
+        await handler(route, request);
+      }, options);
+      return page;
+    };
+    return context;
+  };
+  return browser;
+}

--- a/scripts/hotel-browser-test.mjs
+++ b/scripts/hotel-browser-test.mjs
@@ -99,6 +99,8 @@ try {
     await fill();
     for (const width of [1280, 390]) {
       await page.setViewportSize({ width, height: 1000 });
+      // Filling the date fields can scroll the longer form before this check.
+      await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'instant' }));
       const brand = page.getByRole('link', { name: /Flight Finder home/i });
       const homeBox = await brand.boundingBox();
       const heading = await page.getByRole('heading', { level: 1 }).boundingBox();
@@ -106,9 +108,9 @@ try {
       const navigation = await page.getByRole('link', { name: 'Hotels', exact: true }).boundingBox();
       assert.ok(navigation && homeBox.y + homeBox.height <= navigation.y, 'Home link does not cover hotel navigation');
       const before = homeBox.y;
-      await page.evaluate(() => window.scrollTo(0, 150));
+      await page.evaluate(() => window.scrollTo({ top: 150, behavior: 'instant' }));
       assert.ok((await brand.boundingBox()).y < before - 50, 'Hotel branding scrolls with content');
-      await page.evaluate(() => window.scrollTo(0, 0));
+      await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'instant' }));
     }
     await page.getByRole('button', { name: 'Add room', exact: true }).click();
     await page.getByLabel('Children', { exact: true }).nth(1).fill('1');


### PR DESCRIPTION
Closes #221

## Type
- [x] Feature

## Summary
Import selected Google Flights, Google Hotels, Booking.com, DiscoverCars and Auto Europe links from their respective search forms.

## Problem
Users cannot start tracking directly from an existing selection.

## Fix
Decode links into reviewable details and preserve selection identity during verification and tracking. Require complete hotel occupancy and rental driver details. Reject changed selections and unverified prices.

## Testing
- [x] `npm run ci`: 2,907 tests passed, lint, types and both builds passed.
- [x] Browser and database tests passed.
- [x] Live provider checks and rendered form checks passed.
- [x] Tests and API documentation updated.

Live flight validation covers itinerary and currency. AI extraction was tested through a mocked provider boundary. Auto Europe correctly refused a quote with unconfirmed mandatory fees.

## Review assistance
- [x] No preference.
